### PR TITLE
fix: prevent graph crash when a node's parent folder node is missing

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -110,6 +110,10 @@ export default class Folders2GraphPlugin extends Plugin {
 			Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
 				if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
 					const directParent = this.__getNodeParentFolder(nodeId);
+					// Parent folder may be absent (folder-set vs parent-calc mismatch); create it, don't crash.
+					if (data.nodes[directParent] == null) {
+						data.nodes[directParent] = { type: FOLDER_NODE_TAG, links: {}, folderNode: true };
+					}
 					data.nodes[directParent].links[nodeId] = true;
 				}
 			});

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -10,7 +10,7 @@ import { SettingsTab } from "SettingsTab";
 const FOLDER_NODE_TAG = "tag";
 
 export default class Folders2GraphPlugin extends Plugin {
-	public settings: Settings = {
+	public override settings: Settings = {
 		hideRootNode: false,
 	};
 

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -16,7 +16,7 @@ export class SettingsTab extends PluginSettingTab {
 	/**
 	 * Render the settings tab in the UI.
 	 */
-	public display(): void {
+	public override display(): void {
 		let { containerEl } = this;
 
 		containerEl.empty();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"strict": true,
+		"ignoreDeprecations": "6.0",
 
 		"target": "ESNext",
 		"module": "NodeNext",


### PR DESCRIPTION
## Problem

Enabling the plugin can crash the graph render with:

```
Plugin failure: folders2graph TypeError: Cannot read properties of undefined (reading 'links')
    at t.setData (plugin:folders2graph:1)
    at e.render (app.js)
    at t.onload (app.js)
```

## Root cause

In the custom `setData` (`src/Main.ts`), the set of folder nodes is built using `__getNodeParentFolders` (plural), which is only run over non-tag / non-folder nodes. Links are then assigned using `__getNodeParentFolder` (singular), which additionally applies `.filter((e) => e != "")` on the path segments.

For node IDs where the two calculations diverge (e.g. IDs containing empty/leading-slash segments), the computed `directParent` was never added to `data.nodes`, so:

```ts
data.nodes[directParent].links[nodeId] = true; // directParent node is undefined
```

throws.

## Fix

Create the parent folder node on demand if it doesn't already exist, instead of assuming it does. Minimal, preserves existing behaviour for the common case.

```ts
const directParent = this.__getNodeParentFolder(nodeId);
if (data.nodes[directParent] == null) {
    data.nodes[directParent] = { type: FOLDER_NODE_TAG, links: {}, folderNode: true };
}
data.nodes[directParent].links[nodeId] = true;
```

## Also included: build fix

`typescript` isn't pinned, so a fresh `npm install` pulls a newer major that no longer compiles the repo as-is. Second commit fixes:

- **TS4114** — add `override` modifiers on the overridden `Plugin.settings` field and `PluginSettingTab.display()` method (`noImplicitOverride` is on).
- **TS5101** — `baseUrl` is deprecated; add `"ignoreDeprecations": "6.0"` to `tsconfig.json`.

After this, `npm run build` compiles cleanly (verified locally on Node 26 / TypeScript current; the crash fix is present in the emitted `build/main.js`).
