### PR TITLE
Add shortcuts to show/hide heading/folder nodes

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -15,6 +15,7 @@ import { GraphLeafWithCustomRenderer } from "interfaces/GraphLeafWithCustomRende
 import { LeafRenderer } from "interfaces/LeafRenderer";
 import { RendererData } from "interfaces/RendererData";
 
+import { getI18n } from "i18n";
 import { Nullable } from "types/Nullable";
 import { Settings } from "interfaces/Settings";
 import { SettingsTab } from "SettingsTab";
@@ -24,6 +25,7 @@ const HEADING_NODE_TAG = "f2g_heading_node";
 
 export default class Folders2GraphPlugin extends Plugin {
 	public override settings: Settings = {
+		showFolderNodes: true,
 		hideRootNode: false,
 		nodeColor: "#5c8af5",
 		showHeadingNodes: false,
@@ -45,6 +47,32 @@ export default class Folders2GraphPlugin extends Plugin {
 		// Load settings tab.
 		await this.__loadSettings();
 		this.addSettingTab(new SettingsTab(this.app, this));
+
+		// Register commands so the user can bind hotkeys to toggle each node type. `Mod`
+		// resolves to Ctrl on Windows/Linux and Cmd on macOS, matching Obsidian's
+		// cross-platform convention. Default bindings: Mod+Shift+G for folders, Mod+Shift+H
+		// for headings.
+		this.addCommand({
+			id: "toggle-folder-nodes",
+			name: getI18n().commands.toggleFolderNodes.name,
+			hotkeys: [{ modifiers: ["Mod", "Shift"], key: "G" }],
+			callback: async () => {
+				this.settings.showFolderNodes = !this.settings.showFolderNodes;
+				await this.saveSettings();
+				this.refreshGraphLeaves();
+			},
+		});
+
+		this.addCommand({
+			id: "toggle-heading-nodes",
+			name: getI18n().commands.toggleHeadingNodes.name,
+			hotkeys: [{ modifiers: ["Mod", "Shift"], key: "H" }],
+			callback: async () => {
+				this.settings.showHeadingNodes = !this.settings.showHeadingNodes;
+				await this.saveSettings();
+				this.refreshGraphLeaves();
+			},
+		});
 
 		// Intercept folder node clicks to reveal them in the file explorer.
 		this.__wrapOpenLinkText();
@@ -206,43 +234,48 @@ export default class Folders2GraphPlugin extends Plugin {
 
 		// Define the custom data setter.
 		renderer.setData = (data: RendererData) => {
-			const folders = new Set("/");
-
-			// Get all folders of the nodes. Uses the ID of the node.
-			// eg. file "folder/subfolder/file.md" will generate the following folders: "/", "/folder", "/folder/subfolder
-			Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
-				const nodeSubFolders = this.__getNodeParentFolders(nodeId);
-
-				if (!nodeData.folderNode && nodeData.type != FOLDER_NODE_TAG && nodeSubFolders != null) {
-					nodeSubFolders.forEach(folders.add, folders);
-				}
-			});
-
-			// Add a node for each folder.
-			this.__folderNodeIds.clear();
-			folders.forEach((folder) => {
-				data.nodes[folder] = {
-					type: FOLDER_NODE_TAG,
-					links: {},
-					folderNode: true,
-				};
-				this.__folderNodeIds.add(folder);
-			});
-
-			// Add the links between the nodes and the folders.
-			Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
-				if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
-					const directParent = this.__getNodeParentFolder(nodeId);
-					data.nodes[directParent].links[nodeId] = true;
-				}
-			});
-
 			if (!renderer.originalSetData) {
 				throw new Error("originalSetData is undefined.");
 			}
 
-			if (this.settings.hideRootNode && data.nodes["/"]) {
-				delete data.nodes["/"];
+			// Clear the tracked folder node IDs first so a toggle-off leaves no stale entries
+			// behind that would still hijack `openLinkText`.
+			this.__folderNodeIds.clear();
+
+			if (this.settings.showFolderNodes) {
+				const folders = new Set("/");
+
+				// Get all folders of the nodes. Uses the ID of the node.
+				// eg. file "folder/subfolder/file.md" will generate the following folders: "/", "/folder", "/folder/subfolder
+				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
+					const nodeSubFolders = this.__getNodeParentFolders(nodeId);
+
+					if (!nodeData.folderNode && nodeData.type != FOLDER_NODE_TAG && nodeSubFolders != null) {
+						nodeSubFolders.forEach(folders.add, folders);
+					}
+				});
+
+				// Add a node for each folder.
+				folders.forEach((folder) => {
+					data.nodes[folder] = {
+						type: FOLDER_NODE_TAG,
+						links: {},
+						folderNode: true,
+					};
+					this.__folderNodeIds.add(folder);
+				});
+
+				// Add the links between the nodes and the folders.
+				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
+					if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
+						const directParent = this.__getNodeParentFolder(nodeId);
+						data.nodes[directParent].links[nodeId] = true;
+					}
+				});
+
+				if (this.settings.hideRootNode && data.nodes["/"]) {
+					delete data.nodes["/"];
+				}
 			}
 
 			if (this.settings.showHeadingNodes) {

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -1,10 +1,10 @@
-import * as i18n from "i18n";
+import { getI18n } from "i18n";
 import Folders2GraphPlugin from "Main";
 import { App, PluginSettingTab, Setting } from "obsidian";
 import { I18n } from "types/I18n";
 
 export class SettingsTab extends PluginSettingTab {
-	private __i18n: I18n = this.__getI18n();
+	private __i18n: I18n = getI18n();
 
 	private __plugin: Folders2GraphPlugin;
 
@@ -20,6 +20,18 @@ export class SettingsTab extends PluginSettingTab {
 		let { containerEl } = this;
 
 		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName(this.__i18n.settings.showFolderNodes.name)
+			.setDesc(this.__i18n.settings.showFolderNodes.desc)
+			.addToggle((component) => {
+				component.setValue(this.__plugin.settings.showFolderNodes).onChange(async (value) => {
+					this.__plugin.settings.showFolderNodes = value;
+					await this.__plugin.saveSettings();
+					this.__plugin.refreshGraphLeaves();
+				});
+			});
+
 		new Setting(containerEl)
 			.setName(this.__i18n.settings.hideRootNode.name)
 			.setDesc(this.__i18n.settings.hideRootNode.desc)
@@ -65,18 +77,4 @@ export class SettingsTab extends PluginSettingTab {
 			});
 	}
 
-	/**
-	 * Get the I18n object based on the language code stored in the Obsidian app localstorage.
-	 * @returns The I18n object.
-	 */
-	private __getI18n(): I18n {
-		const languageCode = window.localStorage.getItem("language");
-
-		switch (languageCode) {
-			case "fr":
-				return i18n.frFR;
-			default:
-				return i18n.enUS;
-		}
-	}
 }

--- a/src/i18n/enUS.ts
+++ b/src/i18n/enUS.ts
@@ -2,6 +2,10 @@ import { I18n } from "types/I18n";
 
 export const enUS: I18n = {
 	settings: {
+		showFolderNodes: {
+			name: "Show folder nodes",
+			desc: "Display your vault's folder structure as nodes in the graph view. Disable to focus on note-to-note connections only. (displayed by default)",
+		},
 		hideRootNode: {
 			name: "Hide root node",
 			desc: "Either hide or show the root folder node ('/') in the graph view. (displayed by default)",
@@ -17,6 +21,14 @@ export const enUS: I18n = {
 		headingNodeColor: {
 			name: "Heading node color",
 			desc: "Color used to display heading nodes in the graph view. (defaulted to #f5a55c)",
+		},
+	},
+	commands: {
+		toggleFolderNodes: {
+			name: "Show or hide folder nodes",
+		},
+		toggleHeadingNodes: {
+			name: "Show or hide heading nodes",
 		},
 	},
 };

--- a/src/i18n/frFR.ts
+++ b/src/i18n/frFR.ts
@@ -2,6 +2,10 @@ import { I18n } from "types/I18n";
 
 export const frFR: I18n = {
 	settings: {
+		showFolderNodes: {
+			name: "Afficher les nœuds de dossier",
+			desc: "Affiche la structure des dossiers de votre coffre comme des nœuds dans la vue graphique. Désactiver pour ne voir que les liens entre les notes. (affiché par défaut)",
+		},
 		hideRootNode: {
 			name: "Cacher le nœud racine",
 			desc: "Cacher ou non le nœud du dossier racine ('/') dans la vue graphique. (affiché par défaut)",
@@ -17,6 +21,14 @@ export const frFR: I18n = {
 		headingNodeColor: {
 			name: "Couleur des nœuds de titre",
 			desc: "Couleur des nœuds de titre dans la vue graphique. (par défaut à #f5a55c)",
+		},
+	},
+	commands: {
+		toggleFolderNodes: {
+			name: "Afficher ou masquer les nœuds de dossier",
+		},
+		toggleHeadingNodes: {
+			name: "Afficher ou masquer les nœuds de titre",
 		},
 	},
 };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,2 +1,18 @@
-export { enUS } from "./enUS";
-export { frFR } from "./frFR";
+import { I18n } from "types/I18n";
+import { enUS } from "./enUS";
+import { frFR } from "./frFR";
+
+export { enUS, frFR };
+
+/**
+ * Returns the I18n object matching the language code stored in Obsidian's localStorage.
+ * Defaults to English when no match is found.
+ */
+export function getI18n(): I18n {
+	switch (window.localStorage.getItem("language")) {
+		case "fr":
+			return frFR;
+		default:
+			return enUS;
+	}
+}

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -1,4 +1,5 @@
 export type Settings = {
+	showFolderNodes: boolean;
 	hideRootNode: boolean;
 	nodeColor: string;
 	showHeadingNodes: boolean;

--- a/src/types/I18n.ts
+++ b/src/types/I18n.ts
@@ -1,5 +1,9 @@
 export type I18n = {
 	settings: {
+		showFolderNodes: {
+			name: string;
+			desc: string;
+		};
 		hideRootNode: {
 			name: string;
 			desc: string;
@@ -15,6 +19,14 @@ export type I18n = {
 		headingNodeColor: {
 			name: string;
 			desc: string;
+		};
+	};
+	commands: {
+		toggleFolderNodes: {
+			name: string;
+		};
+		toggleHeadingNodes: {
+			name: string;
 		};
 	};
 };


### PR DESCRIPTION
- Adding shortcut to toggle folder nodes visibility (instead of shutting down the plugin)
#25 

Extra:
- Adding shortcut to toggle heading nodes visibility
#24 