### PR TITLE
Issue/32

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1,27 +1,21 @@
 import {
-	CachedMetadata,
-	HeadingCache,
-	OpenViewState,
-	PaneType,
 	Plugin,
-	TFile,
-	TFolder,
-	Workspace,
 	WorkspaceLeaf,
-	getLinkpath,
 } from "obsidian";
 
 import { GraphLeafWithCustomRenderer } from "interfaces/GraphLeafWithCustomRenderer";
 import { LeafRenderer } from "interfaces/LeafRenderer";
-import { RendererData } from "interfaces/RendererData";
 
 import { getI18n } from "i18n";
 import { Nullable } from "types/Nullable";
 import { Settings } from "interfaces/Settings";
 import { SettingsTab } from "SettingsTab";
 
-const FOLDER_NODE_TAG = "f2g_node";
-const HEADING_NODE_TAG = "f2g_heading_node";
+import { StructuralHierarchy } from "graph/StructuralHierarchy";
+import { FoldingManager } from "graph/FoldingManager";
+import { GraphDataInjector } from "graph/GraphDataInjector";
+import { NodePrototypePatcher } from "graph/NodePrototypePatcher";
+import { GraphInteractions } from "graph/GraphInteractions";
 
 export default class Folders2GraphPlugin extends Plugin {
 	public override settings: Settings = {
@@ -33,63 +27,15 @@ export default class Folders2GraphPlugin extends Plugin {
 		hiddenNodes: {},
 	};
 
-	/** IDs of folder nodes currently injected into the graph. Used to identify folder
-	 * clicks in the wrapped `openLinkText` without relying on the brittle `startsWith("/")`
-	 * heuristic, which could collide with unusual user wikilinks. */
-	private __folderNodeIds = new Set<string>();
-
-	/** Original `workspace.openLinkText` saved when we wrap it, so we can restore on unload. */
-	private __originalOpenLinkText: Nullable<Workspace["openLinkText"]> = null;
-
-	/** Structural children map: for every node ID, the list of IDs that are its direct
-	 * structural children (sub-folders, direct files, or headings). Populated explicitly
-	 * at the exact points where hierarchy links are created in setData. */
-	private __structuralChildren: Record<string, string[]> = {};
-
-	/** Inverse of `__structuralChildren`: maps each child node ID to its structural parent.
-	 * Populated alongside `__structuralChildren` for O(1) parent lookups. */
-	private __structuralParent: Record<string, string> = {};
-
-	/** Full set of node IDs present in the last complete graph data, used for purging
-	 * stale entries from `settings.hiddenNodes` and for validating Shift+click targets. */
-	private __allNodeIds: Set<string> = new Set();
-
-	/** Pre-computed set of node IDs that are currently fully collapsed (all structural
-	 * descendants are in `settings.hiddenNodes`). Updated in setData for O(1) frame-time
-	 * lookups in the render patch. */
-	private __collapsedNodeIds: Set<string> = new Set();
-
 	/** Serialised save queue — every saveData call is chained so concurrent saves never
 	 * race. Always append to this promise; never await it directly. */
 	private __savePromise: Promise<void> = Promise.resolve();
 
-	/** True while the Shift key is held down. Tracked via capture-phase keydown/keyup on
-	 * window, with a blur-reset to handle cases where keyup is missed. */
-	private __shiftHeld = false;
-
-	/** Arrow-function handlers stored so the same references can be passed to
-	 * removeEventListener on unload. */
-	private __onKeyDown = (e: KeyboardEvent): void => {
-		if (e.key === "Shift") this.__shiftHeld = true;
-	};
-	private __onKeyUp = (e: KeyboardEvent): void => {
-		if (e.key === "Shift") this.__shiftHeld = false;
-	};
-	private __onBlur = (): void => {
-		this.__shiftHeld = false;
-	};
-
-	/** Set to true by the PIXI rightdown wrapper when it swallows a Shift+right-click with
-	 * hidden descendants, so the subsequent DOM `contextmenu` event can be suppressed without
-	 * any coordinate hit-testing. Reset immediately after consumption. */
-	private __suppressNextContextMenu = false;
-
-	/** WeakMap from a leaf's containerEl to its AbortController, used for the DOM
-	 * contextmenu suppression listener. */
-	private __contextMenuAbortControllers: WeakMap<HTMLElement, AbortController> = new WeakMap();
-
-	/** Flat set of all active AbortControllers so onunload can abort them all. */
-	private __activeAbortControllers: Set<AbortController> = new Set();
+	private __hierarchy!: StructuralHierarchy;
+	private __foldingManager!: FoldingManager;
+	private __injector!: GraphDataInjector;
+	private __patcher!: NodePrototypePatcher;
+	private __interactions!: GraphInteractions;
 
 	/**
 	 * Triggered when the plugin is loaded.
@@ -98,6 +44,40 @@ export default class Folders2GraphPlugin extends Plugin {
 		// Load settings tab.
 		await this.__loadSettings();
 		this.addSettingTab(new SettingsTab(this.app, this));
+
+		// Wire up graph subsystems.
+		this.__hierarchy = new StructuralHierarchy(this.settings);
+
+		this.__foldingManager = new FoldingManager(
+			this.app,
+			this.settings,
+			this.__hierarchy,
+			() => this.saveSettings(),
+			() => this.refreshGraphLeaves(),
+		);
+
+		this.__injector = new GraphDataInjector(
+			this.app,
+			this.settings,
+			this.__hierarchy,
+			this.__foldingManager,
+			() => this.saveSettings(),
+		);
+
+		this.__interactions = new GraphInteractions(
+			this.app,
+			() => this.__injector.getFolderNodeIds(),
+			() => this.__injector.getAllNodeIds(),
+			(nodeId) => this.__foldingManager.handleFoldToggle(nodeId),
+		);
+
+		this.__patcher = new NodePrototypePatcher(
+			this.settings,
+			this.__hierarchy,
+			(nodeId) => this.__foldingManager.handleRecursiveUnfold(nodeId),
+			() => this.__interactions.getSuppressNextContextMenu(),
+			(value) => this.__interactions.setSuppressNextContextMenu(value),
+		);
 
 		// Register commands so the user can bind hotkeys to toggle each node type. `Mod`
 		// resolves to Ctrl on Windows/Linux and Cmd on macOS, matching Obsidian's
@@ -138,12 +118,10 @@ export default class Folders2GraphPlugin extends Plugin {
 		});
 
 		// Intercept folder node clicks to reveal them in the file explorer.
-		this.__wrapOpenLinkText();
+		this.__interactions.wrapOpenLinkText();
 
 		// Track Shift key state globally so we can detect Shift+click in openLinkText.
-		window.addEventListener("keydown", this.__onKeyDown, true);
-		window.addEventListener("keyup", this.__onKeyUp, true);
-		window.addEventListener("blur", this.__onBlur, true);
+		this.__interactions.registerKeyListeners();
 
 		// When a leaf changes, refresh all graph leaves.
 		this.registerEvent(
@@ -166,16 +144,13 @@ export default class Folders2GraphPlugin extends Plugin {
 	 * Triggered when the plugin is unloaded.
 	 */
 	public override onunload(): void {
-		this.__unwrapOpenLinkText();
+		this.__interactions.unwrapOpenLinkText();
 
 		// Remove Shift tracking listeners.
-		window.removeEventListener("keydown", this.__onKeyDown, true);
-		window.removeEventListener("keyup", this.__onKeyUp, true);
-		window.removeEventListener("blur", this.__onBlur, true);
+		this.__interactions.unregisterKeyListeners();
 
-		// Abort DOM contextmenu suppression listeners installed by __installContextMenuSuppressor.
-		this.__activeAbortControllers.forEach((controller) => controller.abort());
-		this.__activeAbortControllers.clear();
+		// Abort DOM contextmenu suppression listeners.
+		this.__interactions.abortAllContextMenuSuppressors();
 
 		this.__getLeavesOfTypeGraph().forEach((leaf) => {
 			// A `graph`-typed leaf can exist without a mounted renderer (e.g. the view never
@@ -184,98 +159,18 @@ export default class Folders2GraphPlugin extends Plugin {
 			const renderer = leaf.view.renderer;
 			if (!renderer) return;
 
-			// Restablish the original data setter in the render, then delete the custom on, then reload the leaf.
+			// Restablish the original data setter in the render, then delete the custom one, then reload the leaf.
 			if (renderer.originalSetData) {
 				renderer.setData = renderer.originalSetData;
 				delete renderer.originalSetData;
 			}
 
-			this.__unpatchNodePrototype(renderer);
+			this.__patcher.unpatch(renderer);
 
 			leaf.view.unload();
 			leaf.view.load();
 			renderer.changed();
 		});
-	}
-
-	/**
-	 * Wraps `workspace.openLinkText` so that clicks on folder nodes reveal the corresponding
-	 * folder in the file explorer instead of failing to resolve a non-existent file. The
-	 * wrapper only intercepts linktexts that match a currently-injected folder node ID, so
-	 * regular wikilink clicks are unaffected.
-	 */
-	private __wrapOpenLinkText(): void {
-		const workspace = this.app.workspace;
-		this.__originalOpenLinkText = workspace.openLinkText.bind(workspace);
-
-		workspace.openLinkText = (
-			linktext: string,
-			sourcePath: string,
-			newLeaf?: PaneType | boolean,
-			openViewState?: OpenViewState,
-		): Promise<void> => {
-			// Shift+left-click on a graph node → toggle its fold state instead of navigating.
-			// Guarded on the most recent leaf being a graph view: clicking a node activates
-			// its leaf before openLinkText fires, while a Shift+click on an editor wikilink
-			// keeps the editor leaf active — so editor links are never swallowed.
-			const activeIsGraph =
-				this.app.workspace.getMostRecentLeaf()?.view?.getViewType?.() === "graph";
-			if (this.__shiftHeld && activeIsGraph && this.__allNodeIds.has(linktext)) {
-				this.__handleFoldToggle(linktext);
-				return Promise.resolve();
-			}
-
-			if (this.__folderNodeIds.has(linktext)) {
-				this.__revealFolderInExplorer(linktext);
-				return Promise.resolve();
-			}
-			return this.__originalOpenLinkText!(linktext, sourcePath, newLeaf, openViewState);
-		};
-	}
-
-	/**
-	 * Restores the original `workspace.openLinkText`.
-	 */
-	private __unwrapOpenLinkText(): void {
-		if (!this.__originalOpenLinkText) return;
-		this.app.workspace.openLinkText = this.__originalOpenLinkText;
-		this.__originalOpenLinkText = null;
-	}
-
-	/**
-	 * Reveals the folder backing a folder node in Obsidian's file explorer. Folder node IDs
-	 * use a leading `/` and a `/`-rooted path (e.g. `/work/notes`); the vault stores paths
-	 * without the leading slash, and the vault root is `""`.
-	 */
-	private __revealFolderInExplorer(folderNodeId: string): void {
-		const vaultPath = folderNodeId === "/" ? "" : folderNodeId.slice(1);
-		const folder: Nullable<TFolder> =
-			vaultPath === ""
-				? this.app.vault.getRoot()
-				: (this.app.vault.getAbstractFileByPath(vaultPath) as Nullable<TFolder>);
-		if (!folder) return;
-
-		// Make sure a file-explorer leaf exists and is in focus.
-		let leaf = this.app.workspace.getLeavesOfType("file-explorer")[0];
-		if (!leaf) {
-			const leftLeaf = this.app.workspace.getLeftLeaf(false);
-			if (leftLeaf) {
-				leftLeaf.setViewState({ type: "file-explorer" });
-				leaf = leftLeaf;
-			}
-		}
-		if (!leaf) return;
-		this.app.workspace.revealLeaf(leaf);
-
-		// `revealInFolder` is exposed by the internal `file-explorer` plugin instance.
-		// Not part of the public API — fall back silently if it ever moves.
-		const fileExplorerInstance = (this.app as unknown as {
-			internalPlugins?: {
-				getPluginById?: (id: string) => { instance?: { revealInFolder?: (f: TFolder) => void } };
-			};
-		}).internalPlugins?.getPluginById?.("file-explorer")?.instance;
-
-		fileExplorerInstance?.revealInFolder?.(folder);
 	}
 
 	/**
@@ -295,7 +190,7 @@ export default class Folders2GraphPlugin extends Plugin {
 			leaf.view.load();
 			// Install the contextmenu suppressor AFTER unload/load — the reload may rebuild
 			// the view's DOM, which would orphan a listener installed before it.
-			this.__installContextMenuSuppressor(leaf);
+			this.__interactions.installContextMenuSuppressor(leaf);
 			leaf.view.renderer.changed();
 		});
 	}
@@ -311,701 +206,12 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
-	 * Renders the graph leaf with a custom renderer.
-	 * @param leaf The graph leaf to render.
+	 * Installs the custom `setData` override on the renderer of the given leaf.
+	 * @param leaf The graph leaf to inject data into.
 	 */
 	private __injectDataInLeaf(leaf: GraphLeafWithCustomRenderer): void {
 		const renderer = leaf.view.renderer;
-
-		// Store the original data setter in another property, then override the data setter with a custom one.
-		if (renderer.originalSetData == undefined) {
-			renderer.originalSetData = renderer.setData;
-		}
-
-		// Define the custom data setter.
-		renderer.setData = (data: RendererData) => {
-			if (!renderer.originalSetData) {
-				throw new Error("originalSetData is undefined.");
-			}
-
-			// Clear the tracked folder node IDs first so a toggle-off leaves no stale entries
-			// behind that would still hijack `openLinkText`.
-			this.__folderNodeIds.clear();
-
-			// Reset structural maps before (re)building them during this setData.
-			this.__structuralChildren = {};
-			this.__structuralParent = {};
-
-			if (this.settings.showFolderNodes) {
-				const folders = new Set("/");
-
-				// Get all folders of the nodes. Uses the ID of the node.
-				// eg. file "folder/subfolder/file.md" will generate the following folders: "/", "/folder", "/folder/subfolder
-				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
-					const nodeSubFolders = this.__getNodeParentFolders(nodeId);
-
-					if (!nodeData.folderNode && nodeData.type != FOLDER_NODE_TAG && nodeSubFolders != null) {
-						nodeSubFolders.forEach(folders.add, folders);
-					}
-				});
-
-				// Add a node for each folder.
-				folders.forEach((folder) => {
-					data.nodes[folder] = {
-						type: FOLDER_NODE_TAG,
-						links: {},
-						folderNode: true,
-					};
-					this.__folderNodeIds.add(folder);
-				});
-
-				// Add the links between the nodes and the folders, and register structural
-				// parent→child relationships explicitly.
-				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
-					if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
-						const directParent = this.__getNodeParentFolder(nodeId);
-						data.nodes[directParent].links[nodeId] = true;
-						// Register structural hierarchy.
-						this.__addStructuralChild(directParent, nodeId);
-					}
-				});
-
-				if (this.settings.hideRootNode && data.nodes["/"]) {
-					delete data.nodes["/"];
-				}
-			}
-
-			if (this.settings.showHeadingNodes) {
-				// Snapshot the file-like node IDs before injection so we don't iterate over the
-				// folder/heading nodes we just added.
-				const sourceNodeIds = Object.keys(data.nodes).filter((nodeId) => {
-					const nodeData = data.nodes[nodeId];
-					return nodeData.type !== FOLDER_NODE_TAG && nodeData.type !== HEADING_NODE_TAG;
-				});
-				sourceNodeIds.forEach((nodeId) => this.__injectHeadingNodesForFile(data, nodeId));
-			}
-
-			// Record the complete graph state (post-injection, pre-filter) for fold logic
-			// and for validating Shift+click targets in the openLinkText wrapper.
-			this.__allNodeIds = new Set(Object.keys(data.nodes));
-
-			// Purge stale entries from hiddenNodes based on vault existence, NOT on what is
-			// currently rendered. Purging against the rendered graph would incorrectly remove
-			// all heading entries when showHeadingNodes is off, or all sub-folder entries when
-			// showFolderNodes is off — corrupting the collapsed state for the next re-enable.
-			// A conservative approach is used: when an ID format is unrecognised, we keep it
-			// rather than risk destroying user state (a superfluous entry is harmless; a wrong
-			// purge is destructive).
-			let purged = false;
-			for (const id of Object.keys(this.settings.hiddenNodes)) {
-				if (!this.__isNodeIdValidInVault(id)) {
-					delete this.settings.hiddenNodes[id];
-					purged = true;
-				}
-			}
-			if (purged) {
-				// Serialised save — does not block rendering.
-				this.saveSettings();
-			}
-
-			// Pre-compute the collapsed set for O(1) frame-time lookups.
-			this.__collapsedNodeIds = this.__computeCollapsedSet();
-
-			// Filter hidden nodes from the data before passing to the renderer.
-			for (const id of Object.keys(this.settings.hiddenNodes)) {
-				delete data.nodes[id];
-			}
-			// Also remove links pointing to hidden nodes from every remaining node.
-			for (const nodeData of Object.values(data.nodes)) {
-				for (const targetId of Object.keys(nodeData.links)) {
-					if (this.settings.hiddenNodes[targetId]) {
-						delete nodeData.links[targetId];
-					}
-				}
-			}
-
-			const result = renderer.originalSetData(data);
-
-			this.__patchNodePrototype(renderer);
-
-			return result;
-		};
-	}
-
-	/**
-	 * Registers `childId` as a structural child of `parentId` in both the
-	 * `__structuralChildren` and `__structuralParent` maps.
-	 *
-	 * Self-relationships are ignored: the root folder `/` is its own computed parent
-	 * (`__getNodeParentFolder("/")` returns `/`), and registering it as its own child
-	 * would make folding the root hide the root node itself.
-	 */
-	private __addStructuralChild(parentId: string, childId: string): void {
-		if (parentId === childId) return;
-		if (!this.__structuralChildren[parentId]) {
-			this.__structuralChildren[parentId] = [];
-		}
-		this.__structuralChildren[parentId].push(childId);
-		this.__structuralParent[childId] = parentId;
-	}
-
-	/**
-	 * Returns all structural descendants of `nodeId` via an iterative depth-first traversal
-	 * of `__structuralChildren`. A `visited` Set guards against accidental cycles.
-	 */
-	private __getAllDescendants(nodeId: string): string[] {
-		const descendants: string[] = [];
-		const visited = new Set<string>();
-		const stack: string[] = [...(this.__structuralChildren[nodeId] ?? [])];
-
-		while (stack.length > 0) {
-			const current = stack.pop()!;
-			if (visited.has(current)) continue;
-			visited.add(current);
-			descendants.push(current);
-			const children = this.__structuralChildren[current];
-			if (children) {
-				for (const child of children) {
-					stack.push(child);
-				}
-			}
-		}
-
-		return descendants;
-	}
-
-	/**
-	 * Returns true if `nodeId` is fully collapsed: it has at least one structural child
-	 * and every descendant is present in `settings.hiddenNodes`.
-	 * For frame-time use, prefer `__collapsedNodeIds.has(nodeId)` after setData.
-	 */
-	private __isNodeCollapsed(nodeId: string): boolean {
-		const children = this.__structuralChildren[nodeId];
-		if (!children || children.length === 0) return false;
-		const descendants = this.__getAllDescendants(nodeId);
-		if (descendants.length === 0) return false;
-		return descendants.every((id) => this.settings.hiddenNodes[id]);
-	}
-
-	/**
-	 * Builds the full set of collapsed node IDs from the current `__structuralChildren` and
-	 * `settings.hiddenNodes`. Called once per setData so frame-time rendering can do O(1)
-	 * `__collapsedNodeIds.has(id)` lookups instead of recomputing per node per frame.
-	 */
-	private __computeCollapsedSet(): Set<string> {
-		const collapsed = new Set<string>();
-		for (const nodeId of Object.keys(this.__structuralChildren)) {
-			if (this.__isNodeCollapsed(nodeId)) {
-				collapsed.add(nodeId);
-			}
-		}
-		return collapsed;
-	}
-
-	/**
-	 * Handles Shift+left-click on a node: fold, or unfold one level.
-	 *
-	 * - No structural children → no-op.
-	 * - All descendants hidden (fully folded) → unfold ONE level: the direct children are
-	 *   removed from `hiddenNodes`; each child keeps its own folded state, so there is no
-	 *   recursion.
-	 * - Otherwise (fully or partially visible) → fold: every structural descendant is added
-	 *   to `hiddenNodes`.
-	 *
-	 * The state is persisted on every change and all graph leaves are refreshed. A single
-	 * descendant traversal is used to derive the folded state and to apply the change.
-	 */
-	private __handleFoldToggle(nodeId: string): void {
-		const children = this.__structuralChildren[nodeId];
-		if (!children || children.length === 0) return;
-
-		const descendants = this.__getAllDescendants(nodeId);
-		if (descendants.length === 0) return;
-
-		const isCollapsed = descendants.every((id) => this.settings.hiddenNodes[id]);
-
-		if (isCollapsed) {
-			// Unfold one level: reveal direct children only.
-			for (const childId of children) {
-				delete this.settings.hiddenNodes[childId];
-			}
-		} else {
-			// Fold: hide every structural descendant.
-			for (const descId of descendants) {
-				this.settings.hiddenNodes[descId] = true;
-			}
-		}
-
-		this.saveSettings();
-		this.refreshGraphLeaves();
-	}
-
-	/**
-	 * Returns true if at least one structural descendant of `nodeId` is currently hidden.
-	 * Shared criterion between the PIXI right-click wrapper (whether to swallow the gesture)
-	 * and `__handleRecursiveUnfold` (whether there is anything to unfold).
-	 */
-	private __hasHiddenDescendant(nodeId: string): boolean {
-		return this.__getAllDescendants(nodeId).some((id) => this.settings.hiddenNodes[id]);
-	}
-
-	/**
-	 * Handles Shift+right-click on a node: recursively unfolds the whole subtree,
-	 * unconditionally — every hidden structural descendant is revealed, whatever the current
-	 * state (fully folded, partially folded or mixed). No-op when nothing is hidden.
-	 */
-	private __handleRecursiveUnfold(nodeId: string): void {
-		const toUnhide = this.__getAllDescendants(nodeId).filter((id) => this.settings.hiddenNodes[id]);
-		if (toUnhide.length === 0) return;
-
-		for (const descId of toUnhide) {
-			delete this.settings.hiddenNodes[descId];
-		}
-
-		this.saveSettings();
-		this.refreshGraphLeaves();
-	}
-
-	/**
-	 * Installs a capture-phase DOM `contextmenu` listener on the graph view container that
-	 * suppresses the native context menu right after the PIXI rightdown wrapper swallowed a
-	 * Shift+right-click. No coordinate hit-testing is involved: the PIXI wrapper sets
-	 * `__suppressNextContextMenu` and this listener merely consumes the flag.
-	 *
-	 * One listener per container: any previous controller for the same container is aborted
-	 * before registering, so repeated refreshGraphLeaves calls never stack listeners.
-	 */
-	private __installContextMenuSuppressor(leaf: GraphLeafWithCustomRenderer): void {
-		const containerEl = leaf.view.containerEl;
-
-		const existing = this.__contextMenuAbortControllers.get(containerEl);
-		if (existing) {
-			existing.abort();
-			this.__activeAbortControllers.delete(existing);
-		}
-
-		const controller = new AbortController();
-		this.__contextMenuAbortControllers.set(containerEl, controller);
-		this.__activeAbortControllers.add(controller);
-
-		containerEl.addEventListener(
-			"contextmenu",
-			(event: MouseEvent) => {
-				if (this.__suppressNextContextMenu) {
-					event.preventDefault();
-					event.stopPropagation();
-					this.__suppressNextContextMenu = false;
-				}
-				// No flag — let the event through so the native context menu appears.
-			},
-			{ capture: true, signal: controller.signal },
-		);
-	}
-
-	/**
-	 * For a given source node, reads its Markdown headings and inserts a heading node per heading,
-	 * linking each link / embed found in the file to the heading it lives under (the closest
-	 * heading above it). Heading node IDs follow Obsidian's wikilink format `path#heading` so
-	 * a default click on the node opens the source note at that section.
-	 *
-	 * Structural relationships registered here:
-	 * - file → root heading (heading with no ancestor in this file)
-	 * - heading → direct sub-heading
-	 * Non-structural links (refs/embeds from a heading to another file) are NOT registered.
-	 */
-	private __injectHeadingNodesForFile(data: RendererData, nodeId: string): void {
-		const file = this.app.metadataCache.getFirstLinkpathDest(nodeId, "");
-		if (!file || file.extension !== "md") return;
-
-		const cache = this.app.metadataCache.getFileCache(file);
-		if (!cache || !cache.headings || cache.headings.length === 0) return;
-
-		const headings = cache.headings;
-		const refs = [...(cache.links ?? []), ...(cache.embeds ?? [])];
-
-		// Create one node per heading.
-		headings.forEach((h) => {
-			const headingId = this.__buildHeadingNodeId(nodeId, h.heading);
-			data.nodes[headingId] = {
-				type: HEADING_NODE_TAG,
-				links: {},
-			};
-		});
-
-		// Wire the heading hierarchy: each heading is attached to the nearest preceding heading
-		// of strictly lower level. Root headings (no such ancestor) are attached to the source
-		// note. Obsidian guarantees `headings` is in document order, so a stack is enough.
-		const ancestors: HeadingCache[] = [];
-		headings.forEach((h) => {
-			while (ancestors.length > 0 && ancestors[ancestors.length - 1].level >= h.level) {
-				ancestors.pop();
-			}
-			const headingId = this.__buildHeadingNodeId(nodeId, h.heading);
-			const parent = ancestors[ancestors.length - 1];
-			const parentId = parent
-				? this.__buildHeadingNodeId(nodeId, parent.heading)
-				: nodeId;
-			data.nodes[parentId].links[headingId] = true;
-			// Register structural relationship (file→heading or heading→sub-heading).
-			this.__addStructuralChild(parentId, headingId);
-			ancestors.push(h);
-		});
-
-		// Attach each referenced note to the heading that contains the reference.
-		// These are NOT structural relationships (a heading linking to another file is a
-		// content link, not a hierarchy link).
-		refs.forEach((ref) => {
-			const owning = this.__findOwningHeading(headings, ref.position.start.line);
-			if (!owning) return;
-
-			const dest = this.app.metadataCache.getFirstLinkpathDest(
-				getLinkpath(ref.link),
-				file.path,
-			);
-			if (!dest) return;
-
-			const linkedNodeId = this.__resolveGraphNodeId(data, dest);
-			if (!linkedNodeId) return;
-
-			const headingId = this.__buildHeadingNodeId(nodeId, owning.heading);
-			data.nodes[headingId].links[linkedNodeId] = true;
-		});
-	}
-
-	/**
-	 * Returns the heading whose start line is the closest above (or equal to) `line`.
-	 * Headings are assumed to be sorted by position (Obsidian guarantees document order).
-	 */
-	private __findOwningHeading(headings: HeadingCache[], line: number): Nullable<HeadingCache> {
-		let owning: Nullable<HeadingCache> = null;
-		for (const h of headings) {
-			if (h.position.start.line <= line) {
-				owning = h;
-			} else {
-				break;
-			}
-		}
-		return owning;
-	}
-
-	/**
-	 * Builds the heading node ID, matching Obsidian's wikilink syntax (`path#heading`)
-	 * so default click handling opens the note at the corresponding section.
-	 */
-	private __buildHeadingNodeId(sourceNodeId: string, heading: string): string {
-		return `${sourceNodeId}#${heading}`;
-	}
-
-	/**
-	 * Resolves a destination TFile to its corresponding graph node ID. The graph stores
-	 * nodes either by their full path or by their basename for ghost links, so we try
-	 * both candidates and fall back to the path.
-	 */
-	private __resolveGraphNodeId(data: RendererData, dest: TFile): Nullable<string> {
-		if (data.nodes[dest.path]) return dest.path;
-		const noExt = dest.extension === "md" ? dest.path.slice(0, -3) : dest.path;
-		if (data.nodes[noExt]) return noExt;
-		if (data.nodes[dest.basename]) return dest.basename;
-		return dest.path;
-	}
-
-	/**
-	 * Patches the Node class prototype so every node instance — current and future —
-	 * returns the configured color for folder nodes, the configured color for heading nodes,
-	 * (best effort) renders collapsed nodes as a semi-circle, and intercepts Shift+right-click
-	 * to trigger recursive unfold.
-	 *
-	 * Patching the prototype (rather than each instance) ensures the override survives node
-	 * recreations triggered by Obsidian without going through our custom `setData`.
-	 */
-	private __patchNodePrototype(renderer: LeafRenderer): void {
-		if (renderer.nodes.length === 0) return;
-
-		const proto = Object.getPrototypeOf(renderer.nodes[0]);
-		if (proto.__f2gPatched) return;
-
-		const originalGetFillColor = proto.getFillColor;
-		const plugin = this;
-
-		proto.__f2gOriginalGetFillColor = originalGetFillColor;
-		proto.getFillColor = function () {
-			if (this.type === FOLDER_NODE_TAG) {
-				return { a: 1, rgb: plugin.__getColorNumber(plugin.settings.nodeColor) };
-			}
-			if (this.type === HEADING_NODE_TAG) {
-				return { a: 1, rgb: plugin.__getColorNumber(plugin.settings.headingNodeColor) };
-			}
-			return originalGetFillColor.call(this);
-		};
-
-		// Heading nodes use the wikilink syntax `path#heading` as their ID so the native
-		// click handler resolves to the right section, but we want the label to show only the
-		// heading text. If the Node prototype exposes a `getDisplayText` method, override it.
-		const originalGetDisplayText = proto.getDisplayText;
-		if (typeof originalGetDisplayText === "function") {
-			proto.__f2gOriginalGetDisplayText = originalGetDisplayText;
-			proto.getDisplayText = function () {
-				if (this.type === HEADING_NODE_TAG) {
-					return plugin.__extractHeadingFromNodeId(this.id);
-				}
-				return originalGetDisplayText.call(this);
-			};
-		}
-
-		// Patch the node render method (its name varies across Obsidian builds) so that, once
-		// per node instance, the PIXI listeners of the node circle are wrapped to intercept
-		// Shift+right-click. Obsidian registers its own circle listeners (which open the
-		// native context menu) BEFORE ours, so simply adding another listener could not
-		// prevent the native behaviour — the existing listeners are detached and re-invoked
-		// conditionally instead.
-		const renderMethodName = (["render", "draw", "updateGraphics"] as const).find(
-			(name) => typeof proto[name] === "function",
-		) as string | undefined;
-
-		if (renderMethodName) {
-			const originalRender = proto[renderMethodName];
-			proto[`__f2gOriginal_${renderMethodName}`] = originalRender;
-
-			proto[renderMethodName] = function (...args: unknown[]) {
-				originalRender.apply(this, args);
-
-				// Early-out: nothing to do if there is no PIXI circle to patch.
-				if (!this.circle) return;
-
-				// Wrap the circle's PIXI listeners once per node instance. The wrapping is
-				// discarded naturally when unload/load reconstructs the graph view nodes.
-				if (!this.__f2gRightClickWrapped) {
-					this.__f2gRightClickWrapped = true;
-					try {
-						const circle = this.circle as {
-							on?: (event: string, fn: (e: unknown) => void, ctx?: unknown) => void;
-							off?: (event: string, fn: (e: unknown) => void) => void;
-							listeners?: (event: string) => Array<(e: unknown) => void>;
-						};
-						const nodeId: string = this.id;
-
-						// Helper: detach all existing listeners for an event and return them.
-						const detach = (eventName: string): Array<(e: unknown) => void> => {
-							const fns = circle.listeners?.(eventName) ?? [];
-							for (const fn of fns) {
-								circle.off?.(eventName, fn);
-							}
-							return fns;
-						};
-
-						// Helper: forward an event to all original listeners.
-						const forward = (fns: Array<(e: unknown) => void>, e: unknown) => {
-							for (const fn of fns) {
-								fn.call(undefined, e);
-							}
-						};
-
-						// Wrap rightdown: the gate that triggers unfold and sets the suppress flag.
-						const origRightdown = detach("rightdown");
-						circle.on?.("rightdown", (e: unknown) => {
-							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
-							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
-							if (native?.shiftKey && plugin.__hasHiddenDescendant(nodeId)) {
-								plugin.__suppressNextContextMenu = true;
-								plugin.__handleRecursiveUnfold(nodeId);
-								// Do NOT forward — we are suppressing the native context menu.
-								return;
-							}
-							forward(origRightdown, e);
-						});
-
-						// Wrap rightup: swallow if the suppress flag is already set (same gesture).
-						const origRightup = detach("rightup");
-						circle.on?.("rightup", (e: unknown) => {
-							if (plugin.__suppressNextContextMenu) {
-								// Flag still set → this rightup belongs to the swallowed gesture.
-								return;
-							}
-							forward(origRightup, e);
-						});
-
-						// Wrap rightclick: same — swallow companion events of the same gesture.
-						const origRightclick = detach("rightclick");
-						circle.on?.("rightclick", (e: unknown) => {
-							if (plugin.__suppressNextContextMenu) {
-								return;
-							}
-							forward(origRightclick, e);
-						});
-
-						// Wrap pointerdown: swallow only button=2 + Shift + hiddenDescendant to
-						// avoid interfering with left-button drag/navigation events.
-						const origPointerdown = detach("pointerdown");
-						circle.on?.("pointerdown", (e: unknown) => {
-							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
-							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
-							if (
-								native?.button === 2 &&
-								native?.shiftKey &&
-								plugin.__hasHiddenDescendant(nodeId)
-							) {
-								// Swallow — rightdown handles the actual action.
-								return;
-							}
-							forward(origPointerdown, e);
-						});
-					} catch (err) {
-						// Silently ignore — if the PIXI API differs, native behaviour is preserved.
-					}
-				}
-
-				const isCollapsed = plugin.__collapsedNodeIds.has(this.id);
-
-				if (isCollapsed) {
-					// ── FOLDED STATE ────────────────────────────────────────────────────────
-					// Redraw the half-disc every frame so that:
-					//   • the orientation tracks the parent as positions change during layout,
-					//   • any full-circle repaint by Obsidian (e.g. on hover) is overridden.
-					// This is bounded to the number of visible collapsed nodes, so it is
-					// acceptable in practice.
-					try {
-						// Measure the native base radius AND centre from the local geometry on
-						// first encounter (before we clear it). Both are cached per-instance.
-						// Obsidian draws the circle at a large local radius (~100) and uses the
-						// DisplayObject scale for sizing, so getSize() is wrong here.
-						// The centre must be captured because PIXI geometry is not necessarily
-						// centred on (0, 0) — drawing at (0, 0) would appear shifted by one
-						// radius. Fallbacks: radius=100, centre=(0, 0).
-						//
-						// Color: draw in white (0xffffff) so that Obsidian's per-frame `tint`
-						// on the DisplayObject applies the correct node colour (hover included),
-						// exactly as the native full circle does.
-						if (!this.__f2gBaseRadius) {
-							let r = 0;
-							let cx = 0;
-							let cy = 0;
-							if (typeof this.circle.getLocalBounds === "function") {
-								const b = this.circle.getLocalBounds();
-								r = Math.max(b.width, b.height) / 2;
-								cx = b.x + b.width / 2;
-								cy = b.y + b.height / 2;
-							}
-							this.__f2gBaseRadius = r > 0 && isFinite(r) ? r : 100;
-							this.__f2gBaseCenter = { x: cx, y: cy };
-						}
-						const baseRadius: number = this.__f2gBaseRadius;
-						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
-						const cx: number = baseCenter.x;
-						const cy: number = baseCenter.y;
-
-						// Determine the angle pointing toward the structural parent: the rounded
-						// side of the half-disc faces the parent (arc from angle − π/2 to
-						// angle + π/2). Renderer coordinates and PIXI arc angles share the same
-						// y-down convention, so atan2 gives the correct on-screen direction.
-						// Falls back to upward (−π/2) when the parent position is unavailable.
-						let angle = -Math.PI / 2;
-						const parentId = plugin.__structuralParent[this.id];
-						if (parentId !== undefined) {
-							// O(1) lookup through this.renderer.nodeLookup when available,
-							// falling back to a scan of this.renderer.nodes. Always read from
-							// the per-instance renderer — the prototype is shared across all
-							// graph leaves, so no renderer reference may be captured here.
-							const r = this.renderer;
-							let parentNode: { x: number; y: number } | undefined;
-							if (r?.nodeLookup) {
-								parentNode = r.nodeLookup[parentId];
-							} else if (r?.nodes) {
-								parentNode = r.nodes.find((n: { id: string }) => n.id === parentId);
-							}
-							if (parentNode) {
-								angle = Math.atan2(parentNode.y - this.y, parentNode.x - this.x);
-							}
-						}
-
-						this.circle.clear();
-						this.circle.beginFill(0xffffff, 1);
-						this.circle.moveTo(cx, cy);
-						this.circle.arc(cx, cy, baseRadius, angle - Math.PI / 2, angle + Math.PI / 2);
-						if (typeof this.circle.closePath === "function") {
-							this.circle.closePath();
-						}
-						this.circle.endFill();
-
-						this.__f2gHalfDrawn = true;
-					} catch (err) {
-						// Restore the normal circle if the custom drawing failed mid-way — a
-						// clear() without a successful redraw would leave the node invisible.
-						try {
-							originalRender.apply(this, args);
-						} catch (err2) {
-							// Silently ignore if originalRender also fails.
-						}
-					}
-				} else if (this.__f2gHalfDrawn) {
-					// ── TRANSITION: just unfolded ─── restore the full circle once. Obsidian
-					// does not redraw the circle geometry on its own, so a custom drawing
-					// persists until we replace it ourselves.
-					try {
-						const baseRadius: number = this.__f2gBaseRadius ?? 100;
-						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
-
-						this.circle.clear();
-						this.circle.beginFill(0xffffff, 1);
-						if (typeof this.circle.drawCircle === "function") {
-							this.circle.drawCircle(baseCenter.x, baseCenter.y, baseRadius);
-						} else {
-							this.circle.moveTo(baseCenter.x, baseCenter.y);
-							this.circle.arc(baseCenter.x, baseCenter.y, baseRadius, 0, 2 * Math.PI);
-						}
-						this.circle.endFill();
-					} catch (err) {
-						try {
-							originalRender.apply(this, args);
-						} catch (err2) {
-							// Silently ignore if originalRender also fails.
-						}
-					}
-					this.__f2gHalfDrawn = false;
-				}
-			};
-		}
-
-		proto.__f2gPatched = true;
-	}
-
-	/**
-	 * Extracts the heading portion of a heading node ID (`path#heading` → `heading`).
-	 * Uses `indexOf` (first `#`) so that headings whose text itself contains `#` are
-	 * handled consistently — such IDs are a known degraded case.
-	 * Falls back to the full ID when no `#` is present.
-	 */
-	private __extractHeadingFromNodeId(nodeId: string): string {
-		const idx = nodeId.indexOf("#");
-		return idx >= 0 ? nodeId.slice(idx + 1) : nodeId;
-	}
-
-	/**
-	 * Restores the original `getFillColor` on the Node prototype. Called on plugin unload.
-	 */
-	private __unpatchNodePrototype(renderer: LeafRenderer): void {
-		if (renderer.nodes.length === 0) return;
-
-		const proto = Object.getPrototypeOf(renderer.nodes[0]);
-		if (!proto.__f2gPatched) return;
-
-		proto.getFillColor = proto.__f2gOriginalGetFillColor;
-		delete proto.__f2gOriginalGetFillColor;
-
-		if (proto.__f2gOriginalGetDisplayText) {
-			proto.getDisplayText = proto.__f2gOriginalGetDisplayText;
-			delete proto.__f2gOriginalGetDisplayText;
-		}
-
-		// Restore the patched render method, whichever name was found at patch time.
-		for (const name of ["render", "draw", "updateGraphics"]) {
-			const savedName = `__f2gOriginal_${name}`;
-			if (proto[savedName]) {
-				proto[name] = proto[savedName];
-				delete proto[savedName];
-			}
-		}
-
-		delete proto.__f2gPatched;
+		this.__injector.install(renderer, (r: LeafRenderer) => this.__patcher.patch(r));
 	}
 
 	/**
@@ -1014,96 +220,6 @@ export default class Folders2GraphPlugin extends Plugin {
 	 */
 	private __getLeavesOfTypeGraph(): GraphLeafWithCustomRenderer[] {
 		return this.app.workspace.getLeavesOfType("graph") as GraphLeafWithCustomRenderer[];
-	}
-
-	/**
-	 * Get the parent folders of a node.
-	 * @param nodeId The ID of the node.
-	 * @returns Will return each folder and subfolder of the node.
-	 * @example
-	 * const nodeId = "folder/subfolder/file.md";
-	 * const result = __getNodeParentFolders(nodeId);
-	 * // result = ["/", "/folder", "/folder/subfolder"]
-	 */
-	private __getNodeParentFolders(nodeId: string): string[] {
-		const subFolders = ["/"];
-
-		const splittedNodeId = nodeId.split("/");
-		const subFoldersSteps = splittedNodeId.slice(0, splittedNodeId.length - 1);
-
-		let currentFolder = "";
-		subFoldersSteps.forEach((subfolder) => {
-			currentFolder += "/" + subfolder;
-			subFolders.push(currentFolder);
-		});
-
-		return subFolders;
-	}
-
-	/**
-	 * Get the parent folder of a node.
-	 * @param nodeId The ID of the node.
-	 * @returns The parent folder of the node.
-	 * @example
-	 * const nodeId = "folder/subfolder/file.md";
-	 * const result = __getNodeParentFolder(nodeId);
-	 * // result = "/folder/subfolder"
-	 */
-	private __getNodeParentFolder(nodeId: string): string {
-		const splittedNodeId = nodeId.split("/");
-		const subFoldersSteps = splittedNodeId.slice(0, splittedNodeId.length - 1).filter((e) => e != "");
-
-		return `/${subFoldersSteps.join("/")}`;
-	}
-
-	/**
-	 * Returns true if a node ID stored in `settings.hiddenNodes` still corresponds to a
-	 * real vault item, independent of the current `showFolderNodes`/`showHeadingNodes`
-	 * toggles. This allows the purge to run without being influenced by which node types
-	 * are currently rendered.
-	 *
-	 * Rules by ID format:
-	 * - Folder IDs start with `/` (or equal `/`): `/` is always valid (vault root);
-	 *   others are valid when `app.vault.getAbstractFileByPath(id.slice(1))` returns a
-	 *   TFolder.
-	 * - Heading IDs contain `#`: the portion before the first `#` must resolve to a file
-	 *   via `metadataCache.getFirstLinkpathDest`, AND the portion after the first `#` must
-	 *   appear as a heading text in that file's cache.
-	 * - Everything else (plain file IDs): valid when either
-	 *   `metadataCache.getFirstLinkpathDest(id, "")` or `vault.getAbstractFileByPath(id)`
-	 *   returns a non-null result. The graph may store IDs as full paths or as basenames
-	 *   without extension, so both lookups are tried.
-	 *
-	 * When in doubt the method returns `true` (conservative: keep the entry). A superfluous
-	 * entry in hiddenNodes is invisible to the user; a premature purge destroys their
-	 * carefully arranged collapsed state.
-	 */
-	private __isNodeIdValidInVault(id: string): boolean {
-		// Folder node: starts with `/`.
-		if (id.startsWith("/")) {
-			if (id === "/") return true; // Vault root is always present.
-			const vaultPath = id.slice(1);
-			const item = this.app.vault.getAbstractFileByPath(vaultPath);
-			return item instanceof TFolder;
-		}
-
-		// Heading node: contains `#`.
-		const hashIdx = id.indexOf("#");
-		if (hashIdx >= 0) {
-			const filePart = id.slice(0, hashIdx);
-			const headingText = id.slice(hashIdx + 1);
-			const file = this.app.metadataCache.getFirstLinkpathDest(filePart, "");
-			if (!file) return false;
-			const headings = this.app.metadataCache.getFileCache(file)?.headings;
-			if (!headings) return false;
-			return headings.some((h) => h.heading === headingText);
-		}
-
-		// Plain file node: try linkpath resolution first (handles basenames without ext),
-		// then a direct path lookup (native graph uses full paths as IDs).
-		if (this.app.metadataCache.getFirstLinkpathDest(id, "") !== null) return true;
-		if (this.app.vault.getAbstractFileByPath(id) !== null) return true;
-		return false;
 	}
 
 	/**
@@ -1124,22 +240,5 @@ export default class Folders2GraphPlugin extends Plugin {
 				console.error("folders2graph: failed to save settings", err);
 			});
 		return this.__savePromise;
-	}
-
-	/**
-	 * Get the node color number.
-	 * @description The color is stored in hex format and the renderer uses a number which is the concatenation of the binary values of the RGB components.
-	 * @example
-	 * const color = "#001100"; // (00000000 00000001 0000001)
-	 * const result = __getNodeColorNumber(color);
-	 * // result = 129
-	 * @returns
-	 */
-	private __getColorNumber(hexColor: string): number {
-		const r = parseInt(hexColor.substring(1, 3), 16).toString(2).padStart(8, "0");
-		const g = parseInt(hexColor.substring(3, 5), 16).toString(2).padStart(8, "0");
-		const b = parseInt(hexColor.substring(5, 7), 16).toString(2).padStart(8, "0");
-
-		return parseInt(r + g + b, 2);
 	}
 }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -125,6 +125,18 @@ export default class Folders2GraphPlugin extends Plugin {
 			},
 		});
 
+		// Safety-net command that clears all collapsed state at once. No default hotkey so
+		// the user must bind one deliberately, avoiding accidental triggering.
+		this.addCommand({
+			id: "unfold-all-nodes",
+			name: getI18n().commands.unfoldAllNodes.name,
+			callback: async () => {
+				this.settings.hiddenNodes = {};
+				await this.saveSettings();
+				this.refreshGraphLeaves();
+			},
+		});
+
 		// Intercept folder node clicks to reveal them in the file explorer.
 		this.__wrapOpenLinkText();
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -63,6 +63,22 @@ export default class Folders2GraphPlugin extends Plugin {
 	 * race. Always append to this promise; never await it directly. */
 	private __savePromise: Promise<void> = Promise.resolve();
 
+	/** True while the Shift key is held down. Tracked via capture-phase keydown/keyup on
+	 * window, with a blur-reset to handle cases where keyup is missed. */
+	private __shiftHeld = false;
+
+	/** Arrow-function handlers stored so the same references can be passed to
+	 * removeEventListener on unload. */
+	private __onKeyDown = (e: KeyboardEvent): void => {
+		if (e.key === "Shift") this.__shiftHeld = true;
+	};
+	private __onKeyUp = (e: KeyboardEvent): void => {
+		if (e.key === "Shift") this.__shiftHeld = false;
+	};
+	private __onBlur = (): void => {
+		this.__shiftHeld = false;
+	};
+
 	/**
 	 * Triggered when the plugin is loaded.
 	 */
@@ -100,6 +116,11 @@ export default class Folders2GraphPlugin extends Plugin {
 		// Intercept folder node clicks to reveal them in the file explorer.
 		this.__wrapOpenLinkText();
 
+		// Track Shift key state globally so we can detect Shift+click in openLinkText.
+		window.addEventListener("keydown", this.__onKeyDown, true);
+		window.addEventListener("keyup", this.__onKeyUp, true);
+		window.addEventListener("blur", this.__onBlur, true);
+
 		// When a leaf changes, refresh all graph leaves.
 		this.registerEvent(
 			this.app.workspace.on("active-leaf-change", (leaf: Nullable<WorkspaceLeaf>) => {
@@ -122,6 +143,11 @@ export default class Folders2GraphPlugin extends Plugin {
 	 */
 	public override onunload(): void {
 		this.__unwrapOpenLinkText();
+
+		// Remove Shift tracking listeners.
+		window.removeEventListener("keydown", this.__onKeyDown, true);
+		window.removeEventListener("keyup", this.__onKeyUp, true);
+		window.removeEventListener("blur", this.__onBlur, true);
 
 		this.__getLeavesOfTypeGraph().forEach((leaf) => {
 			// A `graph`-typed leaf can exist without a mounted renderer (e.g. the view never
@@ -160,6 +186,17 @@ export default class Folders2GraphPlugin extends Plugin {
 			newLeaf?: PaneType | boolean,
 			openViewState?: OpenViewState,
 		): Promise<void> => {
+			// Shift+left-click on a graph node → toggle its fold state instead of navigating.
+			// Guarded on the most recent leaf being a graph view: clicking a node activates
+			// its leaf before openLinkText fires, while a Shift+click on an editor wikilink
+			// keeps the editor leaf active — so editor links are never swallowed.
+			const activeIsGraph =
+				this.app.workspace.getMostRecentLeaf()?.view?.getViewType?.() === "graph";
+			if (this.__shiftHeld && activeIsGraph && this.__allNodeIds.has(linktext)) {
+				this.__handleFoldToggle(linktext);
+				return Promise.resolve();
+			}
+
 			if (this.__folderNodeIds.has(linktext)) {
 				this.__revealFolderInExplorer(linktext);
 				return Promise.resolve();
@@ -432,6 +469,44 @@ export default class Folders2GraphPlugin extends Plugin {
 			}
 		}
 		return collapsed;
+	}
+
+	/**
+	 * Handles Shift+left-click on a node: fold, or unfold one level.
+	 *
+	 * - No structural children → no-op.
+	 * - All descendants hidden (fully folded) → unfold ONE level: the direct children are
+	 *   removed from `hiddenNodes`; each child keeps its own folded state, so there is no
+	 *   recursion.
+	 * - Otherwise (fully or partially visible) → fold: every structural descendant is added
+	 *   to `hiddenNodes`.
+	 *
+	 * The state is persisted on every change and all graph leaves are refreshed. A single
+	 * descendant traversal is used to derive the folded state and to apply the change.
+	 */
+	private __handleFoldToggle(nodeId: string): void {
+		const children = this.__structuralChildren[nodeId];
+		if (!children || children.length === 0) return;
+
+		const descendants = this.__getAllDescendants(nodeId);
+		if (descendants.length === 0) return;
+
+		const isCollapsed = descendants.every((id) => this.settings.hiddenNodes[id]);
+
+		if (isCollapsed) {
+			// Unfold one level: reveal direct children only.
+			for (const childId of children) {
+				delete this.settings.hiddenNodes[childId];
+			}
+		} else {
+			// Fold: hide every structural descendant.
+			for (const descId of descendants) {
+				this.settings.hiddenNodes[descId] = true;
+			}
+		}
+
+		this.saveSettings();
+		this.refreshGraphLeaves();
 	}
 
 	/**

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -79,6 +79,18 @@ export default class Folders2GraphPlugin extends Plugin {
 		this.__shiftHeld = false;
 	};
 
+	/** Set to true by the PIXI rightdown wrapper when it swallows a Shift+right-click with
+	 * hidden descendants, so the subsequent DOM `contextmenu` event can be suppressed without
+	 * any coordinate hit-testing. Reset immediately after consumption. */
+	private __suppressNextContextMenu = false;
+
+	/** WeakMap from a leaf's containerEl to its AbortController, used for the DOM
+	 * contextmenu suppression listener. */
+	private __contextMenuAbortControllers: WeakMap<HTMLElement, AbortController> = new WeakMap();
+
+	/** Flat set of all active AbortControllers so onunload can abort them all. */
+	private __activeAbortControllers: Set<AbortController> = new Set();
+
 	/**
 	 * Triggered when the plugin is loaded.
 	 */
@@ -148,6 +160,10 @@ export default class Folders2GraphPlugin extends Plugin {
 		window.removeEventListener("keydown", this.__onKeyDown, true);
 		window.removeEventListener("keyup", this.__onKeyUp, true);
 		window.removeEventListener("blur", this.__onBlur, true);
+
+		// Abort DOM contextmenu suppression listeners installed by __installContextMenuSuppressor.
+		this.__activeAbortControllers.forEach((controller) => controller.abort());
+		this.__activeAbortControllers.clear();
 
 		this.__getLeavesOfTypeGraph().forEach((leaf) => {
 			// A `graph`-typed leaf can exist without a mounted renderer (e.g. the view never
@@ -265,6 +281,9 @@ export default class Folders2GraphPlugin extends Plugin {
 			this.__injectDataInLeaf(leaf);
 			leaf.view.unload();
 			leaf.view.load();
+			// Install the contextmenu suppressor AFTER unload/load — the reload may rebuild
+			// the view's DOM, which would orphan a listener installed before it.
+			this.__installContextMenuSuppressor(leaf);
 			leaf.view.renderer.changed();
 		});
 	}
@@ -510,6 +529,68 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
+	 * Returns true if at least one structural descendant of `nodeId` is currently hidden.
+	 * Shared criterion between the PIXI right-click wrapper (whether to swallow the gesture)
+	 * and `__handleRecursiveUnfold` (whether there is anything to unfold).
+	 */
+	private __hasHiddenDescendant(nodeId: string): boolean {
+		return this.__getAllDescendants(nodeId).some((id) => this.settings.hiddenNodes[id]);
+	}
+
+	/**
+	 * Handles Shift+right-click on a node: recursively unfolds the whole subtree,
+	 * unconditionally — every hidden structural descendant is revealed, whatever the current
+	 * state (fully folded, partially folded or mixed). No-op when nothing is hidden.
+	 */
+	private __handleRecursiveUnfold(nodeId: string): void {
+		const toUnhide = this.__getAllDescendants(nodeId).filter((id) => this.settings.hiddenNodes[id]);
+		if (toUnhide.length === 0) return;
+
+		for (const descId of toUnhide) {
+			delete this.settings.hiddenNodes[descId];
+		}
+
+		this.saveSettings();
+		this.refreshGraphLeaves();
+	}
+
+	/**
+	 * Installs a capture-phase DOM `contextmenu` listener on the graph view container that
+	 * suppresses the native context menu right after the PIXI rightdown wrapper swallowed a
+	 * Shift+right-click. No coordinate hit-testing is involved: the PIXI wrapper sets
+	 * `__suppressNextContextMenu` and this listener merely consumes the flag.
+	 *
+	 * One listener per container: any previous controller for the same container is aborted
+	 * before registering, so repeated refreshGraphLeaves calls never stack listeners.
+	 */
+	private __installContextMenuSuppressor(leaf: GraphLeafWithCustomRenderer): void {
+		const containerEl = leaf.view.containerEl;
+
+		const existing = this.__contextMenuAbortControllers.get(containerEl);
+		if (existing) {
+			existing.abort();
+			this.__activeAbortControllers.delete(existing);
+		}
+
+		const controller = new AbortController();
+		this.__contextMenuAbortControllers.set(containerEl, controller);
+		this.__activeAbortControllers.add(controller);
+
+		containerEl.addEventListener(
+			"contextmenu",
+			(event: MouseEvent) => {
+				if (this.__suppressNextContextMenu) {
+					event.preventDefault();
+					event.stopPropagation();
+					this.__suppressNextContextMenu = false;
+				}
+				// No flag — let the event through so the native context menu appears.
+			},
+			{ capture: true, signal: controller.signal },
+		);
+	}
+
+	/**
 	 * For a given source node, reads its Markdown headings and inserts a heading node per heading,
 	 * linking each link / embed found in the file to the heading it lives under (the closest
 	 * heading above it). Heading node IDs follow Obsidian's wikilink format `path#heading` so
@@ -659,6 +740,110 @@ export default class Folders2GraphPlugin extends Plugin {
 			};
 		}
 
+		// Patch the node render method (its name varies across Obsidian builds) so that, once
+		// per node instance, the PIXI listeners of the node circle are wrapped to intercept
+		// Shift+right-click. Obsidian registers its own circle listeners (which open the
+		// native context menu) BEFORE ours, so simply adding another listener could not
+		// prevent the native behaviour — the existing listeners are detached and re-invoked
+		// conditionally instead.
+		const renderMethodName = (["render", "draw", "updateGraphics"] as const).find(
+			(name) => typeof proto[name] === "function",
+		) as string | undefined;
+
+		if (renderMethodName) {
+			const originalRender = proto[renderMethodName];
+			proto[`__f2gOriginal_${renderMethodName}`] = originalRender;
+
+			proto[renderMethodName] = function (...args: unknown[]) {
+				originalRender.apply(this, args);
+
+				// Early-out: nothing to do if there is no PIXI circle to patch.
+				if (!this.circle) return;
+
+				// Wrap the circle's PIXI listeners once per node instance. The wrapping is
+				// discarded naturally when unload/load reconstructs the graph view nodes.
+				if (!this.__f2gRightClickWrapped) {
+					this.__f2gRightClickWrapped = true;
+					try {
+						const circle = this.circle as {
+							on?: (event: string, fn: (e: unknown) => void, ctx?: unknown) => void;
+							off?: (event: string, fn: (e: unknown) => void) => void;
+							listeners?: (event: string) => Array<(e: unknown) => void>;
+						};
+						const nodeId: string = this.id;
+
+						// Helper: detach all existing listeners for an event and return them.
+						const detach = (eventName: string): Array<(e: unknown) => void> => {
+							const fns = circle.listeners?.(eventName) ?? [];
+							for (const fn of fns) {
+								circle.off?.(eventName, fn);
+							}
+							return fns;
+						};
+
+						// Helper: forward an event to all original listeners.
+						const forward = (fns: Array<(e: unknown) => void>, e: unknown) => {
+							for (const fn of fns) {
+								fn.call(undefined, e);
+							}
+						};
+
+						// Wrap rightdown: the gate that triggers unfold and sets the suppress flag.
+						const origRightdown = detach("rightdown");
+						circle.on?.("rightdown", (e: unknown) => {
+							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
+							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
+							if (native?.shiftKey && plugin.__hasHiddenDescendant(nodeId)) {
+								plugin.__suppressNextContextMenu = true;
+								plugin.__handleRecursiveUnfold(nodeId);
+								// Do NOT forward — we are suppressing the native context menu.
+								return;
+							}
+							forward(origRightdown, e);
+						});
+
+						// Wrap rightup: swallow if the suppress flag is already set (same gesture).
+						const origRightup = detach("rightup");
+						circle.on?.("rightup", (e: unknown) => {
+							if (plugin.__suppressNextContextMenu) {
+								// Flag still set → this rightup belongs to the swallowed gesture.
+								return;
+							}
+							forward(origRightup, e);
+						});
+
+						// Wrap rightclick: same — swallow companion events of the same gesture.
+						const origRightclick = detach("rightclick");
+						circle.on?.("rightclick", (e: unknown) => {
+							if (plugin.__suppressNextContextMenu) {
+								return;
+							}
+							forward(origRightclick, e);
+						});
+
+						// Wrap pointerdown: swallow only button=2 + Shift + hiddenDescendant to
+						// avoid interfering with left-button drag/navigation events.
+						const origPointerdown = detach("pointerdown");
+						circle.on?.("pointerdown", (e: unknown) => {
+							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
+							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
+							if (
+								native?.button === 2 &&
+								native?.shiftKey &&
+								plugin.__hasHiddenDescendant(nodeId)
+							) {
+								// Swallow — rightdown handles the actual action.
+								return;
+							}
+							forward(origPointerdown, e);
+						});
+					} catch (err) {
+						// Silently ignore — if the PIXI API differs, native behaviour is preserved.
+					}
+				}
+			};
+		}
+
 		proto.__f2gPatched = true;
 	}
 
@@ -688,6 +873,15 @@ export default class Folders2GraphPlugin extends Plugin {
 		if (proto.__f2gOriginalGetDisplayText) {
 			proto.getDisplayText = proto.__f2gOriginalGetDisplayText;
 			delete proto.__f2gOriginalGetDisplayText;
+		}
+
+		// Restore the patched render method, whichever name was found at patch time.
+		for (const name of ["render", "draw", "updateGraphics"]) {
+			const savedName = `__f2gOriginal_${name}`;
+			if (proto[savedName]) {
+				proto[name] = proto[savedName];
+				delete proto[savedName];
+			}
 		}
 
 		delete proto.__f2gPatched;

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -841,6 +841,115 @@ export default class Folders2GraphPlugin extends Plugin {
 						// Silently ignore — if the PIXI API differs, native behaviour is preserved.
 					}
 				}
+
+				const isCollapsed = plugin.__collapsedNodeIds.has(this.id);
+
+				if (isCollapsed) {
+					// ── FOLDED STATE ────────────────────────────────────────────────────────
+					// Redraw the half-disc every frame so that:
+					//   • the orientation tracks the parent as positions change during layout,
+					//   • any full-circle repaint by Obsidian (e.g. on hover) is overridden.
+					// This is bounded to the number of visible collapsed nodes, so it is
+					// acceptable in practice.
+					try {
+						// Measure the native base radius AND centre from the local geometry on
+						// first encounter (before we clear it). Both are cached per-instance.
+						// Obsidian draws the circle at a large local radius (~100) and uses the
+						// DisplayObject scale for sizing, so getSize() is wrong here.
+						// The centre must be captured because PIXI geometry is not necessarily
+						// centred on (0, 0) — drawing at (0, 0) would appear shifted by one
+						// radius. Fallbacks: radius=100, centre=(0, 0).
+						//
+						// Color: draw in white (0xffffff) so that Obsidian's per-frame `tint`
+						// on the DisplayObject applies the correct node colour (hover included),
+						// exactly as the native full circle does.
+						if (!this.__f2gBaseRadius) {
+							let r = 0;
+							let cx = 0;
+							let cy = 0;
+							if (typeof this.circle.getLocalBounds === "function") {
+								const b = this.circle.getLocalBounds();
+								r = Math.max(b.width, b.height) / 2;
+								cx = b.x + b.width / 2;
+								cy = b.y + b.height / 2;
+							}
+							this.__f2gBaseRadius = r > 0 && isFinite(r) ? r : 100;
+							this.__f2gBaseCenter = { x: cx, y: cy };
+						}
+						const baseRadius: number = this.__f2gBaseRadius;
+						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
+						const cx: number = baseCenter.x;
+						const cy: number = baseCenter.y;
+
+						// Determine the angle pointing toward the structural parent: the rounded
+						// side of the half-disc faces the parent (arc from angle − π/2 to
+						// angle + π/2). Renderer coordinates and PIXI arc angles share the same
+						// y-down convention, so atan2 gives the correct on-screen direction.
+						// Falls back to upward (−π/2) when the parent position is unavailable.
+						let angle = -Math.PI / 2;
+						const parentId = plugin.__structuralParent[this.id];
+						if (parentId !== undefined) {
+							// O(1) lookup through this.renderer.nodeLookup when available,
+							// falling back to a scan of this.renderer.nodes. Always read from
+							// the per-instance renderer — the prototype is shared across all
+							// graph leaves, so no renderer reference may be captured here.
+							const r = this.renderer;
+							let parentNode: { x: number; y: number } | undefined;
+							if (r?.nodeLookup) {
+								parentNode = r.nodeLookup[parentId];
+							} else if (r?.nodes) {
+								parentNode = r.nodes.find((n: { id: string }) => n.id === parentId);
+							}
+							if (parentNode) {
+								angle = Math.atan2(parentNode.y - this.y, parentNode.x - this.x);
+							}
+						}
+
+						this.circle.clear();
+						this.circle.beginFill(0xffffff, 1);
+						this.circle.moveTo(cx, cy);
+						this.circle.arc(cx, cy, baseRadius, angle - Math.PI / 2, angle + Math.PI / 2);
+						if (typeof this.circle.closePath === "function") {
+							this.circle.closePath();
+						}
+						this.circle.endFill();
+
+						this.__f2gHalfDrawn = true;
+					} catch (err) {
+						// Restore the normal circle if the custom drawing failed mid-way — a
+						// clear() without a successful redraw would leave the node invisible.
+						try {
+							originalRender.apply(this, args);
+						} catch (err2) {
+							// Silently ignore if originalRender also fails.
+						}
+					}
+				} else if (this.__f2gHalfDrawn) {
+					// ── TRANSITION: just unfolded ─── restore the full circle once. Obsidian
+					// does not redraw the circle geometry on its own, so a custom drawing
+					// persists until we replace it ourselves.
+					try {
+						const baseRadius: number = this.__f2gBaseRadius ?? 100;
+						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
+
+						this.circle.clear();
+						this.circle.beginFill(0xffffff, 1);
+						if (typeof this.circle.drawCircle === "function") {
+							this.circle.drawCircle(baseCenter.x, baseCenter.y, baseRadius);
+						} else {
+							this.circle.moveTo(baseCenter.x, baseCenter.y);
+							this.circle.arc(baseCenter.x, baseCenter.y, baseRadius, 0, 2 * Math.PI);
+						}
+						this.circle.endFill();
+					} catch (err) {
+						try {
+							originalRender.apply(this, args);
+						} catch (err2) {
+							// Silently ignore if originalRender also fails.
+						}
+					}
+					this.__f2gHalfDrawn = false;
+				}
 			};
 		}
 

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -17,7 +17,31 @@ import { GraphDataInjector } from "graph/GraphDataInjector";
 import { NodePrototypePatcher } from "graph/NodePrototypePatcher";
 import { GraphInteractions } from "graph/GraphInteractions";
 
+/**
+ * Entry point for the Folders 2 Graph Obsidian plugin.
+ *
+ * @remarks
+ * This class owns the plugin lifecycle (`onload` / `onunload`) and orchestrates
+ * the five graph subsystems:
+ *
+ * - {@link StructuralHierarchy} — pure parent/child state for fold queries.
+ * - {@link FoldingManager} — fold/unfold operations and stale-entry purge.
+ * - {@link GraphDataInjector} — custom `setData` override that injects virtual
+ *   nodes and filters hidden ones.
+ * - {@link NodePrototypePatcher} — prototype patch for colours, labels, and the
+ *   PIXI half-disc rendering.
+ * - {@link GraphInteractions} — Shift key tracking, `openLinkText` wrapper, and
+ *   per-leaf DOM context-menu suppressor.
+ *
+ * The public API consumed by `SettingsTab` is intentionally minimal:
+ * `plugin.settings` (read), `plugin.saveSettings()` (persist), and
+ * `plugin.refreshGraphLeaves()` (re-render).
+ */
 export default class Folders2GraphPlugin extends Plugin {
+	/**
+	 * Plugin settings. Initialised with defaults; overwritten by
+	 * `__loadSettings` during `onload`.
+	 */
 	public override settings: Settings = {
 		showFolderNodes: true,
 		hideRootNode: false,
@@ -27,8 +51,9 @@ export default class Folders2GraphPlugin extends Plugin {
 		hiddenNodes: {},
 	};
 
-	/** Serialised save queue — every saveData call is chained so concurrent saves never
-	 * race. Always append to this promise; never await it directly. */
+	/** Serialised save queue — every `saveData` call is chained so concurrent
+	 * saves never race each other. Always append to this promise; never await
+	 * it directly from outside `saveSettings`. */
 	private __savePromise: Promise<void> = Promise.resolve();
 
 	private __hierarchy!: StructuralHierarchy;
@@ -39,6 +64,17 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/**
 	 * Triggered when the plugin is loaded.
+	 *
+	 * @remarks
+	 * Execution order:
+	 * 1. Load persisted settings from disk.
+	 * 2. Register the settings tab.
+	 * 3. Instantiate all graph subsystems (after settings are loaded so every
+	 *    subsystem receives the populated settings object).
+	 * 4. Register commands.
+	 * 5. Install the `openLinkText` wrapper and Shift key listeners.
+	 * 6. Register workspace event handlers.
+	 * 7. Refresh all currently open graph leaves.
 	 */
 	public override async onload(): Promise<void> {
 		// Load settings tab.
@@ -142,6 +178,13 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/**
 	 * Triggered when the plugin is unloaded.
+	 *
+	 * @remarks
+	 * Restores every graph leaf to its native state:
+	 * 1. Unwraps `workspace.openLinkText`.
+	 * 2. Removes Shift key and context-menu suppression listeners.
+	 * 3. For each graph leaf with a renderer: restores `originalSetData`,
+	 *    unpatches the node prototype, and reloads the view.
 	 */
 	public override onunload(): void {
 		this.__interactions.unwrapOpenLinkText();
@@ -175,8 +218,20 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/**
 	 * Refreshes the provided graph leaves.
-	 * @param leaves The leaves to refresh. If not provided, all graph leaves will be refreshed.
-	 * @note If a leaf is not a graph, it will be ignored.
+	 *
+	 * @param leaves The leaves to refresh. When omitted, all open graph leaves
+	 *   are refreshed.
+	 *
+	 * @remarks
+	 * Non-graph leaves are silently skipped. The guard is important because the
+	 * `active-leaf-change` event delivers the newly activated leaf regardless
+	 * of its type: running `view.unload(); view.load()` on a non-graph leaf
+	 * (e.g. the file explorer) would rebind its internal listeners and
+	 * duplicate its context-menu handler.
+	 *
+	 * The context-menu suppressor is installed AFTER `unload/load` because the
+	 * reload may rebuild the view's DOM, which would orphan a listener
+	 * installed before it.
 	 */
 	public refreshGraphLeaves(leaves: GraphLeafWithCustomRenderer[] = this.__getLeavesOfTypeGraph()): void {
 		leaves.forEach((leaf) => {
@@ -196,18 +251,27 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
-	 * A graph leaf is considered ready when its view type is `graph` AND its renderer has
-	 * been mounted. The renderer can briefly be undefined when the `active-leaf-change`
-	 * event fires before the graph view finishes initializing, so this guard prevents the
-	 * downstream code from crashing on `renderer.*`.
+	 * Returns `true` when `leaf` is a fully-initialised graph leaf with a
+	 * mounted renderer.
+	 *
+	 * @param leaf Nullable leaf to test.
+	 * @returns Type predicate narrowing to `GraphLeafWithCustomRenderer`.
+	 *
+	 * @remarks
+	 * The renderer can briefly be `undefined` when the `active-leaf-change`
+	 * event fires before the graph view finishes initializing, so this guard
+	 * prevents the downstream code from crashing on `renderer.*`.
 	 */
 	private __isReadyGraphLeaf(leaf: Nullable<GraphLeafWithCustomRenderer>): leaf is GraphLeafWithCustomRenderer {
 		return !!leaf && !!leaf.view && leaf.view.getViewType() === "graph" && !!leaf.view.renderer;
 	}
 
 	/**
-	 * Installs the custom `setData` override on the renderer of the given leaf.
-	 * @param leaf The graph leaf to inject data into.
+	 * Installs the custom `setData` override on the renderer of the given leaf
+	 * via `GraphDataInjector`, passing a callback that applies the node
+	 * prototype patch after each `setData` completes.
+	 *
+	 * @param leaf The graph leaf whose renderer should be patched.
 	 */
 	private __injectDataInLeaf(leaf: GraphLeafWithCustomRenderer): void {
 		const renderer = leaf.view.renderer;
@@ -215,23 +279,34 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
-	 * Get all leaves of type "graph".
-	 * @returns The leaves of type "graph".
+	 * Returns all currently open leaves of type `"graph"`.
+	 *
+	 * @returns Array of graph leaves cast to `GraphLeafWithCustomRenderer`.
 	 */
 	private __getLeavesOfTypeGraph(): GraphLeafWithCustomRenderer[] {
 		return this.app.workspace.getLeavesOfType("graph") as GraphLeafWithCustomRenderer[];
 	}
 
 	/**
-	 * Refresh settings and apply them to `this.settings`.
+	 * Loads persisted settings from disk and merges them over the defaults.
+	 *
+	 * @remarks
+	 * Uses `Object.assign` so settings keys added in a newer plugin version
+	 * keep their default values even when the stored data predates them.
 	 */
 	private async __loadSettings() {
 		this.settings = Object.assign({}, this.settings, await this.loadData());
 	}
 
 	/**
-	 * Call the Obsidian API to save the settings. All calls are serialised through
+	 * Persists `this.settings` to disk. All calls are serialised through
 	 * `__savePromise` so concurrent invocations never race each other.
+	 *
+	 * @returns A `Promise` that resolves when this specific save has completed.
+	 *
+	 * @remarks
+	 * Errors are caught and logged so a failed save does not propagate an
+	 * unhandled rejection to the caller.
 	 */
 	public saveSettings(): Promise<void> {
 		this.__savePromise = this.__savePromise

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -30,6 +30,7 @@ export default class Folders2GraphPlugin extends Plugin {
 		nodeColor: "#5c8af5",
 		showHeadingNodes: false,
 		headingNodeColor: "#f5a55c",
+		hiddenNodes: {},
 	};
 
 	/** IDs of folder nodes currently injected into the graph. Used to identify folder
@@ -39,6 +40,28 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/** Original `workspace.openLinkText` saved when we wrap it, so we can restore on unload. */
 	private __originalOpenLinkText: Nullable<Workspace["openLinkText"]> = null;
+
+	/** Structural children map: for every node ID, the list of IDs that are its direct
+	 * structural children (sub-folders, direct files, or headings). Populated explicitly
+	 * at the exact points where hierarchy links are created in setData. */
+	private __structuralChildren: Record<string, string[]> = {};
+
+	/** Inverse of `__structuralChildren`: maps each child node ID to its structural parent.
+	 * Populated alongside `__structuralChildren` for O(1) parent lookups. */
+	private __structuralParent: Record<string, string> = {};
+
+	/** Full set of node IDs present in the last complete graph data, used for purging
+	 * stale entries from `settings.hiddenNodes` and for validating Shift+click targets. */
+	private __allNodeIds: Set<string> = new Set();
+
+	/** Pre-computed set of node IDs that are currently fully collapsed (all structural
+	 * descendants are in `settings.hiddenNodes`). Updated in setData for O(1) frame-time
+	 * lookups in the render patch. */
+	private __collapsedNodeIds: Set<string> = new Set();
+
+	/** Serialised save queue — every saveData call is chained so concurrent saves never
+	 * race. Always append to this promise; never await it directly. */
+	private __savePromise: Promise<void> = Promise.resolve();
 
 	/**
 	 * Triggered when the plugin is loaded.
@@ -241,6 +264,10 @@ export default class Folders2GraphPlugin extends Plugin {
 			// behind that would still hijack `openLinkText`.
 			this.__folderNodeIds.clear();
 
+			// Reset structural maps before (re)building them during this setData.
+			this.__structuralChildren = {};
+			this.__structuralParent = {};
+
 			if (this.settings.showFolderNodes) {
 				const folders = new Set("/");
 
@@ -264,11 +291,14 @@ export default class Folders2GraphPlugin extends Plugin {
 					this.__folderNodeIds.add(folder);
 				});
 
-				// Add the links between the nodes and the folders.
+				// Add the links between the nodes and the folders, and register structural
+				// parent→child relationships explicitly.
 				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
 					if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
 						const directParent = this.__getNodeParentFolder(nodeId);
 						data.nodes[directParent].links[nodeId] = true;
+						// Register structural hierarchy.
+						this.__addStructuralChild(directParent, nodeId);
 					}
 				});
 
@@ -287,6 +317,45 @@ export default class Folders2GraphPlugin extends Plugin {
 				sourceNodeIds.forEach((nodeId) => this.__injectHeadingNodesForFile(data, nodeId));
 			}
 
+			// Record the complete graph state (post-injection, pre-filter) for fold logic
+			// and for validating Shift+click targets in the openLinkText wrapper.
+			this.__allNodeIds = new Set(Object.keys(data.nodes));
+
+			// Purge stale entries from hiddenNodes based on vault existence, NOT on what is
+			// currently rendered. Purging against the rendered graph would incorrectly remove
+			// all heading entries when showHeadingNodes is off, or all sub-folder entries when
+			// showFolderNodes is off — corrupting the collapsed state for the next re-enable.
+			// A conservative approach is used: when an ID format is unrecognised, we keep it
+			// rather than risk destroying user state (a superfluous entry is harmless; a wrong
+			// purge is destructive).
+			let purged = false;
+			for (const id of Object.keys(this.settings.hiddenNodes)) {
+				if (!this.__isNodeIdValidInVault(id)) {
+					delete this.settings.hiddenNodes[id];
+					purged = true;
+				}
+			}
+			if (purged) {
+				// Serialised save — does not block rendering.
+				this.saveSettings();
+			}
+
+			// Pre-compute the collapsed set for O(1) frame-time lookups.
+			this.__collapsedNodeIds = this.__computeCollapsedSet();
+
+			// Filter hidden nodes from the data before passing to the renderer.
+			for (const id of Object.keys(this.settings.hiddenNodes)) {
+				delete data.nodes[id];
+			}
+			// Also remove links pointing to hidden nodes from every remaining node.
+			for (const nodeData of Object.values(data.nodes)) {
+				for (const targetId of Object.keys(nodeData.links)) {
+					if (this.settings.hiddenNodes[targetId]) {
+						delete nodeData.links[targetId];
+					}
+				}
+			}
+
 			const result = renderer.originalSetData(data);
 
 			this.__patchNodePrototype(renderer);
@@ -296,10 +365,85 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
+	 * Registers `childId` as a structural child of `parentId` in both the
+	 * `__structuralChildren` and `__structuralParent` maps.
+	 *
+	 * Self-relationships are ignored: the root folder `/` is its own computed parent
+	 * (`__getNodeParentFolder("/")` returns `/`), and registering it as its own child
+	 * would make folding the root hide the root node itself.
+	 */
+	private __addStructuralChild(parentId: string, childId: string): void {
+		if (parentId === childId) return;
+		if (!this.__structuralChildren[parentId]) {
+			this.__structuralChildren[parentId] = [];
+		}
+		this.__structuralChildren[parentId].push(childId);
+		this.__structuralParent[childId] = parentId;
+	}
+
+	/**
+	 * Returns all structural descendants of `nodeId` via an iterative depth-first traversal
+	 * of `__structuralChildren`. A `visited` Set guards against accidental cycles.
+	 */
+	private __getAllDescendants(nodeId: string): string[] {
+		const descendants: string[] = [];
+		const visited = new Set<string>();
+		const stack: string[] = [...(this.__structuralChildren[nodeId] ?? [])];
+
+		while (stack.length > 0) {
+			const current = stack.pop()!;
+			if (visited.has(current)) continue;
+			visited.add(current);
+			descendants.push(current);
+			const children = this.__structuralChildren[current];
+			if (children) {
+				for (const child of children) {
+					stack.push(child);
+				}
+			}
+		}
+
+		return descendants;
+	}
+
+	/**
+	 * Returns true if `nodeId` is fully collapsed: it has at least one structural child
+	 * and every descendant is present in `settings.hiddenNodes`.
+	 * For frame-time use, prefer `__collapsedNodeIds.has(nodeId)` after setData.
+	 */
+	private __isNodeCollapsed(nodeId: string): boolean {
+		const children = this.__structuralChildren[nodeId];
+		if (!children || children.length === 0) return false;
+		const descendants = this.__getAllDescendants(nodeId);
+		if (descendants.length === 0) return false;
+		return descendants.every((id) => this.settings.hiddenNodes[id]);
+	}
+
+	/**
+	 * Builds the full set of collapsed node IDs from the current `__structuralChildren` and
+	 * `settings.hiddenNodes`. Called once per setData so frame-time rendering can do O(1)
+	 * `__collapsedNodeIds.has(id)` lookups instead of recomputing per node per frame.
+	 */
+	private __computeCollapsedSet(): Set<string> {
+		const collapsed = new Set<string>();
+		for (const nodeId of Object.keys(this.__structuralChildren)) {
+			if (this.__isNodeCollapsed(nodeId)) {
+				collapsed.add(nodeId);
+			}
+		}
+		return collapsed;
+	}
+
+	/**
 	 * For a given source node, reads its Markdown headings and inserts a heading node per heading,
 	 * linking each link / embed found in the file to the heading it lives under (the closest
 	 * heading above it). Heading node IDs follow Obsidian's wikilink format `path#heading` so
 	 * a default click on the node opens the source note at that section.
+	 *
+	 * Structural relationships registered here:
+	 * - file → root heading (heading with no ancestor in this file)
+	 * - heading → direct sub-heading
+	 * Non-structural links (refs/embeds from a heading to another file) are NOT registered.
 	 */
 	private __injectHeadingNodesForFile(data: RendererData, nodeId: string): void {
 		const file = this.app.metadataCache.getFirstLinkpathDest(nodeId, "");
@@ -334,10 +478,14 @@ export default class Folders2GraphPlugin extends Plugin {
 				? this.__buildHeadingNodeId(nodeId, parent.heading)
 				: nodeId;
 			data.nodes[parentId].links[headingId] = true;
+			// Register structural relationship (file→heading or heading→sub-heading).
+			this.__addStructuralChild(parentId, headingId);
 			ancestors.push(h);
 		});
 
 		// Attach each referenced note to the heading that contains the reference.
+		// These are NOT structural relationships (a heading linking to another file is a
+		// content link, not a hierarchy link).
 		refs.forEach((ref) => {
 			const owning = this.__findOwningHeading(headings, ref.position.start.line);
 			if (!owning) return;
@@ -395,9 +543,12 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/**
 	 * Patches the Node class prototype so every node instance — current and future —
-	 * returns the configured color for folder nodes. Patching the prototype (rather than
-	 * each instance) ensures the override survives node recreations triggered by Obsidian
-	 * (e.g. toggling orphans, tag filters) without going through our custom `setData`.
+	 * returns the configured color for folder nodes, the configured color for heading nodes,
+	 * (best effort) renders collapsed nodes as a semi-circle, and intercepts Shift+right-click
+	 * to trigger recursive unfold.
+	 *
+	 * Patching the prototype (rather than each instance) ensures the override survives node
+	 * recreations triggered by Obsidian without going through our custom `setData`.
 	 */
 	private __patchNodePrototype(renderer: LeafRenderer): void {
 		if (renderer.nodes.length === 0) return;
@@ -438,10 +589,12 @@ export default class Folders2GraphPlugin extends Plugin {
 
 	/**
 	 * Extracts the heading portion of a heading node ID (`path#heading` → `heading`).
+	 * Uses `indexOf` (first `#`) so that headings whose text itself contains `#` are
+	 * handled consistently — such IDs are a known degraded case.
 	 * Falls back to the full ID when no `#` is present.
 	 */
 	private __extractHeadingFromNodeId(nodeId: string): string {
-		const idx = nodeId.lastIndexOf("#");
+		const idx = nodeId.indexOf("#");
 		return idx >= 0 ? nodeId.slice(idx + 1) : nodeId;
 	}
 
@@ -514,6 +667,56 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
+	 * Returns true if a node ID stored in `settings.hiddenNodes` still corresponds to a
+	 * real vault item, independent of the current `showFolderNodes`/`showHeadingNodes`
+	 * toggles. This allows the purge to run without being influenced by which node types
+	 * are currently rendered.
+	 *
+	 * Rules by ID format:
+	 * - Folder IDs start with `/` (or equal `/`): `/` is always valid (vault root);
+	 *   others are valid when `app.vault.getAbstractFileByPath(id.slice(1))` returns a
+	 *   TFolder.
+	 * - Heading IDs contain `#`: the portion before the first `#` must resolve to a file
+	 *   via `metadataCache.getFirstLinkpathDest`, AND the portion after the first `#` must
+	 *   appear as a heading text in that file's cache.
+	 * - Everything else (plain file IDs): valid when either
+	 *   `metadataCache.getFirstLinkpathDest(id, "")` or `vault.getAbstractFileByPath(id)`
+	 *   returns a non-null result. The graph may store IDs as full paths or as basenames
+	 *   without extension, so both lookups are tried.
+	 *
+	 * When in doubt the method returns `true` (conservative: keep the entry). A superfluous
+	 * entry in hiddenNodes is invisible to the user; a premature purge destroys their
+	 * carefully arranged collapsed state.
+	 */
+	private __isNodeIdValidInVault(id: string): boolean {
+		// Folder node: starts with `/`.
+		if (id.startsWith("/")) {
+			if (id === "/") return true; // Vault root is always present.
+			const vaultPath = id.slice(1);
+			const item = this.app.vault.getAbstractFileByPath(vaultPath);
+			return item instanceof TFolder;
+		}
+
+		// Heading node: contains `#`.
+		const hashIdx = id.indexOf("#");
+		if (hashIdx >= 0) {
+			const filePart = id.slice(0, hashIdx);
+			const headingText = id.slice(hashIdx + 1);
+			const file = this.app.metadataCache.getFirstLinkpathDest(filePart, "");
+			if (!file) return false;
+			const headings = this.app.metadataCache.getFileCache(file)?.headings;
+			if (!headings) return false;
+			return headings.some((h) => h.heading === headingText);
+		}
+
+		// Plain file node: try linkpath resolution first (handles basenames without ext),
+		// then a direct path lookup (native graph uses full paths as IDs).
+		if (this.app.metadataCache.getFirstLinkpathDest(id, "") !== null) return true;
+		if (this.app.vault.getAbstractFileByPath(id) !== null) return true;
+		return false;
+	}
+
+	/**
 	 * Refresh settings and apply them to `this.settings`.
 	 */
 	private async __loadSettings() {
@@ -521,10 +724,16 @@ export default class Folders2GraphPlugin extends Plugin {
 	}
 
 	/**
-	 * Call the Obsidian API to save the settings.
+	 * Call the Obsidian API to save the settings. All calls are serialised through
+	 * `__savePromise` so concurrent invocations never race each other.
 	 */
-	public async saveSettings() {
-		await this.saveData(this.settings);
+	public saveSettings(): Promise<void> {
+		this.__savePromise = this.__savePromise
+			.then(() => this.saveData(this.settings))
+			.catch((err: unknown) => {
+				console.error("folders2graph: failed to save settings", err);
+			});
+		return this.__savePromise;
 	}
 
 	/**

--- a/src/SettingsTab.ts
+++ b/src/SettingsTab.ts
@@ -3,11 +3,25 @@ import Folders2GraphPlugin from "Main";
 import { App, PluginSettingTab, Setting } from "obsidian";
 import { I18n } from "types/I18n";
 
+/**
+ * Obsidian settings tab for the Folders 2 Graph plugin.
+ *
+ * @remarks
+ * Renders toggle and colour-picker controls for each plugin setting. Each
+ * control mutates `plugin.settings` directly, then calls
+ * `plugin.saveSettings()` and `plugin.refreshGraphLeaves()` so the graph view
+ * reflects the change immediately.
+ */
 export class SettingsTab extends PluginSettingTab {
 	private __i18n: I18n = getI18n();
 
 	private __plugin: Folders2GraphPlugin;
 
+	/**
+	 * @param app    Obsidian application instance, forwarded to the base class.
+	 * @param plugin Plugin instance whose `settings`, `saveSettings`, and
+	 *   `refreshGraphLeaves` are used by the controls.
+	 */
 	constructor(app: App, plugin: Folders2GraphPlugin) {
 		super(app, plugin);
 		this.__plugin = plugin;
@@ -15,6 +29,11 @@ export class SettingsTab extends PluginSettingTab {
 
 	/**
 	 * Render the settings tab in the UI.
+	 *
+	 * @remarks
+	 * Called by Obsidian whenever the settings panel is opened or the tab is
+	 * selected. Clears the container element and rebuilds all controls from
+	 * scratch.
 	 */
 	public override display(): void {
 		let { containerEl } = this;

--- a/src/graph/FoldingManager.ts
+++ b/src/graph/FoldingManager.ts
@@ -61,6 +61,27 @@ export class FoldingManager {
 	 *
 	 * A single descendant traversal is used to derive the folded state and to
 	 * apply the change.
+	 *
+	 * @example
+	 * // Case 1 — all descendants visible → fold (hide all descendants).
+	 * // Hierarchy: /notes → notes/a.md, notes/b.md
+	 * // Before: hiddenNodes = {}
+	 * foldingManager.handleFoldToggle("/notes");
+	 * // After:  hiddenNodes = { "notes/a.md": true, "notes/b.md": true }
+	 *
+	 * @example
+	 * // Case 2 — partially visible → fold (same behaviour as case 1).
+	 * // Before: hiddenNodes = { "notes/a.md": true }
+	 * foldingManager.handleFoldToggle("/notes");
+	 * // After:  hiddenNodes = { "notes/a.md": true, "notes/b.md": true }
+	 *
+	 * @example
+	 * // Case 3 — fully folded → unfold ONE level (direct children only).
+	 * // Hierarchy: /notes → notes/sub (which itself has notes/sub/deep.md hidden)
+	 * // Before: hiddenNodes = { "notes/sub": true, "notes/sub/deep.md": true }
+	 * foldingManager.handleFoldToggle("/notes");
+	 * // After:  hiddenNodes = { "notes/sub/deep.md": true }
+	 * // notes/sub is now visible but remains collapsed (its child is still hidden).
 	 */
 	handleFoldToggle(nodeId: string): void {
 		const children = this.hierarchy.getChildren(nodeId);
@@ -94,6 +115,14 @@ export class FoldingManager {
 	 * folded, or mixed). No-op when nothing is hidden under `nodeId`.
 	 *
 	 * @param nodeId The node that was Shift+right-clicked.
+	 *
+	 * @example
+	 * // Mixed hidden state: /src → src/api (hidden) → src/api/index.md (hidden)
+	 * //                           src/utils.md (visible)
+	 * // Before: hiddenNodes = { "src/api": true, "src/api/index.md": true }
+	 * foldingManager.handleRecursiveUnfold("/src");
+	 * // After:  hiddenNodes = {}
+	 * // All hidden descendants revealed in one shot, regardless of nesting depth.
 	 */
 	handleRecursiveUnfold(nodeId: string): void {
 		const toUnhide = this.hierarchy
@@ -161,6 +190,33 @@ export class FoldingManager {
 	 *   `vault.getAbstractFileByPath(id)` returns a non-null result. Both are
 	 *   tried because the graph stores IDs either as full paths or as basenames
 	 *   without extension.
+	 *
+	 * @example
+	 * // Folder ID — vault root is always valid.
+	 * foldingManager.isNodeIdValidInVault("/");
+	 * // true
+	 *
+	 * @example
+	 * // Folder ID — arbitrary sub-folder (valid when the TFolder exists in vault).
+	 * foldingManager.isNodeIdValidInVault("/projects/2024");
+	 * // true   when vault contains the folder  projects/2024
+	 * // false  when the folder has been deleted or renamed
+	 *
+	 * @example
+	 * // Heading ID — file part + heading text are both validated.
+	 * foldingManager.isNodeIdValidInVault("journal/2024-01-15#Daily note");
+	 * // true   when  journal/2024-01-15.md  exists and has a heading "Daily note"
+	 * // false  when the file or heading is missing
+	 *
+	 * @example
+	 * // Plain file ID stored as basename (ghost link / unique-name vault).
+	 * foldingManager.isNodeIdValidInVault("readme");
+	 * // true  when  getFirstLinkpathDest("readme", "")  resolves to a TFile
+	 *
+	 * @example
+	 * // Plain file ID stored as full path.
+	 * foldingManager.isNodeIdValidInVault("folder/note.md");
+	 * // true  when  vault.getAbstractFileByPath("folder/note.md")  is non-null
 	 */
 	isNodeIdValidInVault(id: string): boolean {
 		// Folder node: starts with `/`.

--- a/src/graph/FoldingManager.ts
+++ b/src/graph/FoldingManager.ts
@@ -1,0 +1,165 @@
+import { App, TFolder } from "obsidian";
+import { Settings } from "interfaces/Settings";
+import { StructuralHierarchy } from "graph/StructuralHierarchy";
+
+/**
+ * Handles fold/unfold operations on graph nodes and persistence of the
+ * collapsed state.
+ *
+ * `FoldingManager` reads and mutates `settings.hiddenNodes`, then delegates
+ * persistence to the `save` callback and graph refresh to the `refresh`
+ * callback — keeping it decoupled from the plugin lifecycle.
+ */
+export class FoldingManager {
+	private app: App;
+	private settings: Settings;
+	private hierarchy: StructuralHierarchy;
+	private save: () => Promise<void>;
+	private refresh: () => void;
+
+	constructor(
+		app: App,
+		settings: Settings,
+		hierarchy: StructuralHierarchy,
+		save: () => Promise<void>,
+		refresh: () => void,
+	) {
+		this.app = app;
+		this.settings = settings;
+		this.hierarchy = hierarchy;
+		this.save = save;
+		this.refresh = refresh;
+	}
+
+	/**
+	 * Handles Shift+left-click on a node: fold, or unfold one level.
+	 *
+	 * - No structural children → no-op.
+	 * - All descendants hidden (fully folded) → unfold ONE level: the direct
+	 *   children are removed from `hiddenNodes`; each child keeps its own
+	 *   folded state, so there is no recursion.
+	 * - Otherwise (fully or partially visible) → fold: every structural
+	 *   descendant is added to `hiddenNodes`.
+	 *
+	 * The state is persisted on every change and all graph leaves are refreshed.
+	 * A single descendant traversal is used to derive the folded state and to
+	 * apply the change.
+	 */
+	handleFoldToggle(nodeId: string): void {
+		const children = this.hierarchy.getChildren(nodeId);
+		if (children.length === 0) return;
+
+		const descendants = this.hierarchy.getAllDescendants(nodeId);
+		if (descendants.length === 0) return;
+
+		const isCollapsed = descendants.every((id) => this.settings.hiddenNodes[id]);
+
+		if (isCollapsed) {
+			// Unfold one level: reveal direct children only.
+			for (const childId of children) {
+				delete this.settings.hiddenNodes[childId];
+			}
+		} else {
+			// Fold: hide every structural descendant.
+			for (const descId of descendants) {
+				this.settings.hiddenNodes[descId] = true;
+			}
+		}
+
+		this.save();
+		this.refresh();
+	}
+
+	/**
+	 * Handles Shift+right-click on a node: recursively unfolds the whole
+	 * subtree, unconditionally — every hidden structural descendant is
+	 * revealed, whatever the current state (fully folded, partially folded or
+	 * mixed). No-op when nothing is hidden.
+	 */
+	handleRecursiveUnfold(nodeId: string): void {
+		const toUnhide = this.hierarchy
+			.getAllDescendants(nodeId)
+			.filter((id) => this.settings.hiddenNodes[id]);
+		if (toUnhide.length === 0) return;
+
+		for (const descId of toUnhide) {
+			delete this.settings.hiddenNodes[descId];
+		}
+
+		this.save();
+		this.refresh();
+	}
+
+	/**
+	 * Purges stale entries from `settings.hiddenNodes` by checking each stored
+	 * node ID against the vault. Purging is conservative: when an ID format is
+	 * unrecognised the entry is kept rather than risking destruction of user
+	 * state.
+	 *
+	 * Purging is intentionally based on vault existence, NOT on what is
+	 * currently rendered — purging against the rendered graph would incorrectly
+	 * remove all heading entries when `showHeadingNodes` is off.
+	 *
+	 * @returns `true` if at least one entry was removed and settings must be saved.
+	 */
+	purge(): boolean {
+		let purged = false;
+		for (const id of Object.keys(this.settings.hiddenNodes)) {
+			if (!this.isNodeIdValidInVault(id)) {
+				delete this.settings.hiddenNodes[id];
+				purged = true;
+			}
+		}
+		return purged;
+	}
+
+	/**
+	 * Returns true if a node ID stored in `settings.hiddenNodes` still
+	 * corresponds to a real vault item, independent of the current
+	 * `showFolderNodes`/`showHeadingNodes` toggles.
+	 *
+	 * Rules by ID format:
+	 * - Folder IDs start with `/` (or equal `/`): `/` is always valid (vault
+	 *   root); others are valid when
+	 *   `app.vault.getAbstractFileByPath(id.slice(1))` returns a TFolder.
+	 * - Heading IDs contain `#`: the portion before the first `#` must resolve
+	 *   to a file via `metadataCache.getFirstLinkpathDest`, AND the portion
+	 *   after the first `#` must appear as a heading text in that file's cache.
+	 * - Everything else (plain file IDs): valid when either
+	 *   `metadataCache.getFirstLinkpathDest(id, "")` or
+	 *   `vault.getAbstractFileByPath(id)` returns a non-null result. The graph
+	 *   may store IDs as full paths or as basenames without extension, so both
+	 *   lookups are tried.
+	 *
+	 * When in doubt the method returns `true` (conservative: keep the entry).
+	 * A superfluous entry in hiddenNodes is invisible to the user; a premature
+	 * purge destroys their carefully arranged collapsed state.
+	 */
+	isNodeIdValidInVault(id: string): boolean {
+		// Folder node: starts with `/`.
+		if (id.startsWith("/")) {
+			if (id === "/") return true; // Vault root is always present.
+			const vaultPath = id.slice(1);
+			const item = this.app.vault.getAbstractFileByPath(vaultPath);
+			return item instanceof TFolder;
+		}
+
+		// Heading node: contains `#`.
+		const hashIdx = id.indexOf("#");
+		if (hashIdx >= 0) {
+			const filePart = id.slice(0, hashIdx);
+			const headingText = id.slice(hashIdx + 1);
+			const file = this.app.metadataCache.getFirstLinkpathDest(filePart, "");
+			if (!file) return false;
+			const headings = this.app.metadataCache.getFileCache(file)?.headings;
+			if (!headings) return false;
+			return headings.some((h) => h.heading === headingText);
+		}
+
+		// Plain file node: try linkpath resolution first (handles basenames
+		// without ext), then a direct path lookup.
+		if (this.app.metadataCache.getFirstLinkpathDest(id, "") !== null) return true;
+		if (this.app.vault.getAbstractFileByPath(id) !== null) return true;
+		return false;
+	}
+}

--- a/src/graph/FoldingManager.ts
+++ b/src/graph/FoldingManager.ts
@@ -9,6 +9,11 @@ import { StructuralHierarchy } from "graph/StructuralHierarchy";
  * `FoldingManager` reads and mutates `settings.hiddenNodes`, then delegates
  * persistence to the `save` callback and graph refresh to the `refresh`
  * callback — keeping it decoupled from the plugin lifecycle.
+ *
+ * @remarks
+ * All fold operations persist the result via `save` and immediately trigger
+ * `refresh` so the graph view reflects the new state without requiring the
+ * user to do anything.
  */
 export class FoldingManager {
 	private app: App;
@@ -17,6 +22,15 @@ export class FoldingManager {
 	private save: () => Promise<void>;
 	private refresh: () => void;
 
+	/**
+	 * @param app       Obsidian application instance, used for vault lookups in `purge`.
+	 * @param settings  Plugin settings whose `hiddenNodes` map is mutated directly.
+	 * @param hierarchy Structural hierarchy used to traverse parent/child relationships.
+	 * @param save      Callback that persists `settings` to disk; called after every
+	 *   state change.
+	 * @param refresh   Callback that re-renders all graph leaves; called after every
+	 *   state change.
+	 */
 	constructor(
 		app: App,
 		settings: Settings,
@@ -34,14 +48,17 @@ export class FoldingManager {
 	/**
 	 * Handles Shift+left-click on a node: fold, or unfold one level.
 	 *
-	 * - No structural children → no-op.
-	 * - All descendants hidden (fully folded) → unfold ONE level: the direct
-	 *   children are removed from `hiddenNodes`; each child keeps its own
-	 *   folded state, so there is no recursion.
-	 * - Otherwise (fully or partially visible) → fold: every structural
+	 * @param nodeId The node that was Shift+clicked.
+	 *
+	 * @remarks
+	 * Behaviour by current state:
+	 * - **No structural children** → no-op.
+	 * - **All descendants hidden** (fully folded) → unfold ONE level: the
+	 *   direct children are removed from `hiddenNodes`; each child keeps its
+	 *   own folded state, so there is no recursion.
+	 * - **Otherwise** (fully or partially visible) → fold: every structural
 	 *   descendant is added to `hiddenNodes`.
 	 *
-	 * The state is persisted on every change and all graph leaves are refreshed.
 	 * A single descendant traversal is used to derive the folded state and to
 	 * apply the change.
 	 */
@@ -72,9 +89,11 @@ export class FoldingManager {
 
 	/**
 	 * Handles Shift+right-click on a node: recursively unfolds the whole
-	 * subtree, unconditionally — every hidden structural descendant is
-	 * revealed, whatever the current state (fully folded, partially folded or
-	 * mixed). No-op when nothing is hidden.
+	 * subtree unconditionally — every hidden structural descendant is
+	 * revealed, regardless of the current state (fully folded, partially
+	 * folded, or mixed). No-op when nothing is hidden under `nodeId`.
+	 *
+	 * @param nodeId The node that was Shift+right-clicked.
 	 */
 	handleRecursiveUnfold(nodeId: string): void {
 		const toUnhide = this.hierarchy
@@ -92,15 +111,21 @@ export class FoldingManager {
 
 	/**
 	 * Purges stale entries from `settings.hiddenNodes` by checking each stored
-	 * node ID against the vault. Purging is conservative: when an ID format is
-	 * unrecognised the entry is kept rather than risking destruction of user
-	 * state.
+	 * node ID against the vault.
 	 *
-	 * Purging is intentionally based on vault existence, NOT on what is
-	 * currently rendered — purging against the rendered graph would incorrectly
-	 * remove all heading entries when `showHeadingNodes` is off.
+	 * @returns `true` if at least one entry was removed and settings must be
+	 *   saved; `false` when the map was already clean.
 	 *
-	 * @returns `true` if at least one entry was removed and settings must be saved.
+	 * @remarks
+	 * Purging is intentionally conservative: when an ID format is unrecognised
+	 * the entry is kept rather than risking destruction of user state. A
+	 * superfluous entry in `hiddenNodes` is invisible to the user; a premature
+	 * purge destroys their carefully arranged collapsed state.
+	 *
+	 * Purging is based on vault existence, NOT on what is currently rendered —
+	 * purging against the rendered graph would incorrectly remove all heading
+	 * entries when `showHeadingNodes` is off, or all folder entries when
+	 * `showFolderNodes` is off.
 	 */
 	purge(): boolean {
 		let purged = false;
@@ -118,22 +143,24 @@ export class FoldingManager {
 	 * corresponds to a real vault item, independent of the current
 	 * `showFolderNodes`/`showHeadingNodes` toggles.
 	 *
-	 * Rules by ID format:
-	 * - Folder IDs start with `/` (or equal `/`): `/` is always valid (vault
-	 *   root); others are valid when
-	 *   `app.vault.getAbstractFileByPath(id.slice(1))` returns a TFolder.
-	 * - Heading IDs contain `#`: the portion before the first `#` must resolve
-	 *   to a file via `metadataCache.getFirstLinkpathDest`, AND the portion
-	 *   after the first `#` must appear as a heading text in that file's cache.
-	 * - Everything else (plain file IDs): valid when either
-	 *   `metadataCache.getFirstLinkpathDest(id, "")` or
-	 *   `vault.getAbstractFileByPath(id)` returns a non-null result. The graph
-	 *   may store IDs as full paths or as basenames without extension, so both
-	 *   lookups are tried.
+	 * @param id A node ID from `settings.hiddenNodes`.
+	 * @returns `true` when the ID maps to an existing vault item, or when the
+	 *   format is unrecognised (conservative keep).
 	 *
-	 * When in doubt the method returns `true` (conservative: keep the entry).
-	 * A superfluous entry in hiddenNodes is invisible to the user; a premature
-	 * purge destroys their carefully arranged collapsed state.
+	 * @remarks
+	 * Rules by ID format:
+	 * - **Folder IDs** (start with `/`, or equal `/`): `/` is always valid
+	 *   (vault root); others are valid when
+	 *   `app.vault.getAbstractFileByPath(id.slice(1))` returns a `TFolder`.
+	 * - **Heading IDs** (contain `#`): the portion before the first `#` must
+	 *   resolve to a file via `metadataCache.getFirstLinkpathDest`, AND the
+	 *   portion after the first `#` must appear as a heading text in that
+	 *   file's cache.
+	 * - **Plain file IDs**: valid when either
+	 *   `metadataCache.getFirstLinkpathDest(id, "")` or
+	 *   `vault.getAbstractFileByPath(id)` returns a non-null result. Both are
+	 *   tried because the graph stores IDs either as full paths or as basenames
+	 *   without extension.
 	 */
 	isNodeIdValidInVault(id: string): boolean {
 		// Folder node: starts with `/`.

--- a/src/graph/GraphDataInjector.ts
+++ b/src/graph/GraphDataInjector.ts
@@ -1,0 +1,335 @@
+import { App, HeadingCache, TFile, getLinkpath } from "obsidian";
+import { RendererData } from "interfaces/RendererData";
+import { LeafRenderer } from "interfaces/LeafRenderer";
+import { Settings } from "interfaces/Settings";
+import { Nullable } from "types/Nullable";
+import { StructuralHierarchy } from "graph/StructuralHierarchy";
+import { FoldingManager } from "graph/FoldingManager";
+
+const FOLDER_NODE_TAG = "f2g_node";
+const HEADING_NODE_TAG = "f2g_heading_node";
+
+/**
+ * Injects folder nodes and heading nodes into the graph data before it is
+ * passed to Obsidian's native renderer.
+ *
+ * This class is responsible for:
+ * - Enumerating parent folder paths from existing node IDs and inserting a
+ *   virtual folder node for each.
+ * - Wiring structural links between folders, files, and headings.
+ * - Injecting heading nodes derived from each Markdown file's metadata cache.
+ * - Filtering out hidden nodes (from `settings.hiddenNodes`) before the data
+ *   reaches the renderer.
+ * - Triggering the structural hierarchy rebuild and the purge of stale entries
+ *   on every setData call.
+ */
+export class GraphDataInjector {
+	private app: App;
+	private settings: Settings;
+	private hierarchy: StructuralHierarchy;
+	private foldingManager: FoldingManager;
+	private save: () => Promise<void>;
+
+	/** IDs of folder nodes currently injected into the graph. Written here so
+	 * `GraphInteractions` can read it via `getFolderNodeIds()` without
+	 * introducing a circular dependency. */
+	private folderNodeIds: Set<string> = new Set();
+
+	/** Full set of node IDs present in the last complete graph data, used for
+	 * validating Shift+click targets in the openLinkText wrapper. */
+	private allNodeIds: Set<string> = new Set();
+
+	constructor(
+		app: App,
+		settings: Settings,
+		hierarchy: StructuralHierarchy,
+		foldingManager: FoldingManager,
+		save: () => Promise<void>,
+	) {
+		this.app = app;
+		this.settings = settings;
+		this.hierarchy = hierarchy;
+		this.foldingManager = foldingManager;
+		this.save = save;
+	}
+
+	/** Returns the set of injected folder node IDs for the last graph data pass. */
+	getFolderNodeIds(): Set<string> {
+		return this.folderNodeIds;
+	}
+
+	/** Returns the full set of all node IDs from the last graph data pass. */
+	getAllNodeIds(): Set<string> {
+		return this.allNodeIds;
+	}
+
+	/**
+	 * Installs the custom `setData` override on `renderer`. The original
+	 * `setData` is saved as `renderer.originalSetData` so it can be restored
+	 * on plugin unload.
+	 *
+	 * The override:
+	 * 1. Injects folder nodes (when `settings.showFolderNodes` is true).
+	 * 2. Injects heading nodes (when `settings.showHeadingNodes` is true).
+	 * 3. Purges stale `hiddenNodes` entries against the vault.
+	 * 4. Computes the collapsed set for O(1) frame-time lookups.
+	 * 5. Filters hidden nodes from the data.
+	 * 6. Calls the original `setData`.
+	 * 7. Triggers the prototype patch callback so rendering overrides are
+	 *    applied after the node list is populated.
+	 *
+	 * @param renderer The graph leaf renderer to patch.
+	 * @param onAfterSetData Callback invoked after the original `setData` runs;
+	 *   used by the plugin to apply the node prototype patch.
+	 */
+	install(renderer: LeafRenderer, onAfterSetData: (renderer: LeafRenderer) => void): void {
+		if (renderer.originalSetData == undefined) {
+			renderer.originalSetData = renderer.setData;
+		}
+
+		renderer.setData = (data: RendererData) => {
+			if (!renderer.originalSetData) {
+				throw new Error("originalSetData is undefined.");
+			}
+
+			// Clear tracked folder node IDs so a toggle-off leaves no stale
+			// entries behind that would hijack `openLinkText`.
+			this.folderNodeIds.clear();
+
+			// Reset structural maps before (re)building them during this setData.
+			this.hierarchy.reset();
+
+			if (this.settings.showFolderNodes) {
+				const folders = new Set("/");
+
+				// Collect all ancestor folder paths for every existing node.
+				// e.g. "folder/subfolder/file.md" → ["/", "/folder", "/folder/subfolder"]
+				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
+					const nodeSubFolders = this.getNodeParentFolders(nodeId);
+
+					if (!nodeData.folderNode && nodeData.type != FOLDER_NODE_TAG && nodeSubFolders != null) {
+						nodeSubFolders.forEach(folders.add, folders);
+					}
+				});
+
+				// Add a virtual node for each folder path.
+				folders.forEach((folder) => {
+					data.nodes[folder] = {
+						type: FOLDER_NODE_TAG,
+						links: {},
+						folderNode: true,
+					};
+					this.folderNodeIds.add(folder);
+				});
+
+				// Wire each node to its direct parent folder and register the
+				// structural parent→child relationship.
+				Object.entries(data.nodes).forEach(([nodeId, nodeData]) => {
+					if (nodeData.type != FOLDER_NODE_TAG || nodeData.folderNode) {
+						const directParent = this.getNodeParentFolder(nodeId);
+						data.nodes[directParent].links[nodeId] = true;
+						this.hierarchy.addChild(directParent, nodeId);
+					}
+				});
+
+				if (this.settings.hideRootNode && data.nodes["/"]) {
+					delete data.nodes["/"];
+				}
+			}
+
+			if (this.settings.showHeadingNodes) {
+				// Snapshot the file-like node IDs before injection so we don't
+				// iterate over the folder/heading nodes we just added.
+				const sourceNodeIds = Object.keys(data.nodes).filter((nodeId) => {
+					const nodeData = data.nodes[nodeId];
+					return nodeData.type !== FOLDER_NODE_TAG && nodeData.type !== HEADING_NODE_TAG;
+				});
+				sourceNodeIds.forEach((nodeId) => this.injectHeadingNodesForFile(data, nodeId));
+			}
+
+			// Record the complete graph state (post-injection, pre-filter) for
+			// fold logic and for validating Shift+click targets.
+			this.allNodeIds = new Set(Object.keys(data.nodes));
+
+			// Purge stale entries from hiddenNodes based on vault existence.
+			if (this.foldingManager.purge()) {
+				// Serialised save — does not block rendering.
+				this.save();
+			}
+
+			// Pre-compute the collapsed set for O(1) frame-time lookups.
+			this.hierarchy.computeCollapsedSet();
+
+			// Filter hidden nodes from the data before passing to the renderer.
+			for (const id of Object.keys(this.settings.hiddenNodes)) {
+				delete data.nodes[id];
+			}
+			// Also remove links pointing to hidden nodes from every remaining node.
+			for (const nodeData of Object.values(data.nodes)) {
+				for (const targetId of Object.keys(nodeData.links)) {
+					if (this.settings.hiddenNodes[targetId]) {
+						delete nodeData.links[targetId];
+					}
+				}
+			}
+
+			const result = renderer.originalSetData(data);
+
+			onAfterSetData(renderer);
+
+			return result;
+		};
+	}
+
+	/**
+	 * For a given source node, reads its Markdown headings and inserts a
+	 * heading node per heading, linking each link / embed found in the file
+	 * to the heading it lives under (the closest heading above it). Heading
+	 * node IDs follow Obsidian's wikilink format `path#heading` so a default
+	 * click on the node opens the source note at that section.
+	 *
+	 * Structural relationships registered here:
+	 * - file → root heading (heading with no ancestor in this file)
+	 * - heading → direct sub-heading
+	 * Non-structural links (refs/embeds from a heading to another file) are
+	 * NOT registered.
+	 */
+	private injectHeadingNodesForFile(data: RendererData, nodeId: string): void {
+		const file = this.app.metadataCache.getFirstLinkpathDest(nodeId, "");
+		if (!file || file.extension !== "md") return;
+
+		const cache = this.app.metadataCache.getFileCache(file);
+		if (!cache || !cache.headings || cache.headings.length === 0) return;
+
+		const headings = cache.headings;
+		const refs = [...(cache.links ?? []), ...(cache.embeds ?? [])];
+
+		// Create one node per heading.
+		headings.forEach((h) => {
+			const headingId = this.buildHeadingNodeId(nodeId, h.heading);
+			data.nodes[headingId] = {
+				type: HEADING_NODE_TAG,
+				links: {},
+			};
+		});
+
+		// Wire the heading hierarchy: each heading is attached to the nearest
+		// preceding heading of strictly lower level. Root headings (no such
+		// ancestor) are attached to the source note. Obsidian guarantees
+		// `headings` is in document order, so a stack is enough.
+		const ancestors: HeadingCache[] = [];
+		headings.forEach((h) => {
+			while (ancestors.length > 0 && ancestors[ancestors.length - 1].level >= h.level) {
+				ancestors.pop();
+			}
+			const headingId = this.buildHeadingNodeId(nodeId, h.heading);
+			const parent = ancestors[ancestors.length - 1];
+			const parentId = parent
+				? this.buildHeadingNodeId(nodeId, parent.heading)
+				: nodeId;
+			data.nodes[parentId].links[headingId] = true;
+			// Register structural relationship (file→heading or heading→sub-heading).
+			this.hierarchy.addChild(parentId, headingId);
+			ancestors.push(h);
+		});
+
+		// Attach each referenced note to the heading that contains the reference.
+		// These are NOT structural relationships.
+		refs.forEach((ref) => {
+			const owning = this.findOwningHeading(headings, ref.position.start.line);
+			if (!owning) return;
+
+			const dest = this.app.metadataCache.getFirstLinkpathDest(
+				getLinkpath(ref.link),
+				file.path,
+			);
+			if (!dest) return;
+
+			const linkedNodeId = this.resolveGraphNodeId(data, dest);
+			if (!linkedNodeId) return;
+
+			const headingId = this.buildHeadingNodeId(nodeId, owning.heading);
+			data.nodes[headingId].links[linkedNodeId] = true;
+		});
+	}
+
+	/**
+	 * Returns the heading whose start line is the closest above (or equal to)
+	 * `line`. Headings are assumed to be sorted by position (Obsidian
+	 * guarantees document order).
+	 */
+	private findOwningHeading(headings: HeadingCache[], line: number): Nullable<HeadingCache> {
+		let owning: Nullable<HeadingCache> = null;
+		for (const h of headings) {
+			if (h.position.start.line <= line) {
+				owning = h;
+			} else {
+				break;
+			}
+		}
+		return owning;
+	}
+
+	/**
+	 * Builds the heading node ID, matching Obsidian's wikilink syntax
+	 * (`path#heading`) so default click handling opens the note at the
+	 * corresponding section.
+	 */
+	buildHeadingNodeId(sourceNodeId: string, heading: string): string {
+		return `${sourceNodeId}#${heading}`;
+	}
+
+	/**
+	 * Resolves a destination TFile to its corresponding graph node ID. The
+	 * graph stores nodes either by their full path or by their basename for
+	 * ghost links, so both candidates are tried and the path is used as
+	 * fallback.
+	 */
+	private resolveGraphNodeId(data: RendererData, dest: TFile): Nullable<string> {
+		if (data.nodes[dest.path]) return dest.path;
+		const noExt = dest.extension === "md" ? dest.path.slice(0, -3) : dest.path;
+		if (data.nodes[noExt]) return noExt;
+		if (data.nodes[dest.basename]) return dest.basename;
+		return dest.path;
+	}
+
+	/**
+	 * Returns each ancestor folder path of `nodeId` as a `/`-prefixed string,
+	 * including the vault root `/`.
+	 *
+	 * @example
+	 * const nodeId = "folder/subfolder/file.md";
+	 * const result = getNodeParentFolders(nodeId);
+	 * // result = ["/", "/folder", "/folder/subfolder"]
+	 */
+	getNodeParentFolders(nodeId: string): string[] {
+		const subFolders = ["/"];
+
+		const splittedNodeId = nodeId.split("/");
+		const subFoldersSteps = splittedNodeId.slice(0, splittedNodeId.length - 1);
+
+		let currentFolder = "";
+		subFoldersSteps.forEach((subfolder) => {
+			currentFolder += "/" + subfolder;
+			subFolders.push(currentFolder);
+		});
+
+		return subFolders;
+	}
+
+	/**
+	 * Returns the direct parent folder path of `nodeId` as a `/`-prefixed
+	 * string. The vault root `/` is its own parent.
+	 *
+	 * @example
+	 * const nodeId = "folder/subfolder/file.md";
+	 * const result = getNodeParentFolder(nodeId);
+	 * // result = "/folder/subfolder"
+	 */
+	getNodeParentFolder(nodeId: string): string {
+		const splittedNodeId = nodeId.split("/");
+		const subFoldersSteps = splittedNodeId.slice(0, splittedNodeId.length - 1).filter((e) => e != "");
+
+		return `/${subFoldersSteps.join("/")}`;
+	}
+}

--- a/src/graph/GraphDataInjector.ts
+++ b/src/graph/GraphDataInjector.ts
@@ -229,6 +229,21 @@ export class GraphDataInjector {
 	 *
 	 * Non-structural links (refs/embeds from a heading to another file) are
 	 * added as graph links but NOT registered in `StructuralHierarchy`.
+	 *
+	 * @example
+	 * // Source file "docs/guide" has two headings:
+	 * //   # Overview        (level 1)
+	 * //   ## Installation   (level 2, child of Overview)
+	 * //
+	 * // Before injection:
+	 * // data.nodes = { "docs/guide": { type: "", links: {}, ... } }
+	 * //
+	 * // After injectHeadingNodesForFile(data, "docs/guide"):
+	 * // data.nodes = {
+	 * //   "docs/guide":                    { type: "",                links: { "docs/guide#Overview": true } },
+	 * //   "docs/guide#Overview":           { type: "f2g_heading_node", links: { "docs/guide#Installation": true } },
+	 * //   "docs/guide#Installation":       { type: "f2g_heading_node", links: {} },
+	 * // }
 	 */
 	private injectHeadingNodesForFile(data: RendererData, nodeId: string): void {
 		const file = this.app.metadataCache.getFirstLinkpathDest(nodeId, "");
@@ -323,6 +338,16 @@ export class GraphDataInjector {
 	 * @param sourceNodeId Graph node ID of the source file (e.g. `folder/note`).
 	 * @param heading      Raw heading text as it appears in the Markdown file.
 	 * @returns Heading node ID in the form `sourceNodeId#heading`.
+	 *
+	 * @example
+	 * const nodeId = buildHeadingNodeId("docs/api", "Getting Started");
+	 * // nodeId = "docs/api#Getting Started"
+	 *
+	 * @example
+	 * // Heading text that itself contains a `#` character (degraded case).
+	 * const nodeId = buildHeadingNodeId("notes/faq", "What is C#?");
+	 * // nodeId = "notes/faq#What is C#?"
+	 * // extractHeadingFromNodeId will stop at the first `#`, returning "What is C".
 	 */
 	private buildHeadingNodeId(sourceNodeId: string, heading: string): string {
 		return `${sourceNodeId}#${heading}`;
@@ -340,6 +365,20 @@ export class GraphDataInjector {
 	 * The graph stores nodes either by their full path (e.g. `folder/note.md`)
 	 * or by their basename for ghost links (e.g. `note`), so both candidates
 	 * are tried before falling back to the path.
+	 *
+	 * @example
+	 * // Node stored by full path (common in multi-folder vaults).
+	 * // data.nodes = { "projects/roadmap.md": { ... } }
+	 * // dest = { path: "projects/roadmap.md", basename: "roadmap", extension: "md" }
+	 * const id = resolveGraphNodeId(data, dest);
+	 * // id = "projects/roadmap.md"
+	 *
+	 * @example
+	 * // Ghost link stored by basename only (no matching file in the vault).
+	 * // data.nodes = { "roadmap": { ... } }
+	 * // dest = { path: "roadmap.md", basename: "roadmap", extension: "md" }
+	 * const id = resolveGraphNodeId(data, dest);
+	 * // id = "roadmap"  (basename match, path without extension)
 	 */
 	private resolveGraphNodeId(data: RendererData, dest: TFile): Nullable<string> {
 		if (data.nodes[dest.path]) return dest.path;

--- a/src/graph/GraphDataInjector.ts
+++ b/src/graph/GraphDataInjector.ts
@@ -324,7 +324,7 @@ export class GraphDataInjector {
 	 * @param heading      Raw heading text as it appears in the Markdown file.
 	 * @returns Heading node ID in the form `sourceNodeId#heading`.
 	 */
-	buildHeadingNodeId(sourceNodeId: string, heading: string): string {
+	private buildHeadingNodeId(sourceNodeId: string, heading: string): string {
 		return `${sourceNodeId}#${heading}`;
 	}
 
@@ -362,7 +362,7 @@ export class GraphDataInjector {
 	 * const result = getNodeParentFolders(nodeId);
 	 * // result = ["/", "/folder", "/folder/subfolder"]
 	 */
-	getNodeParentFolders(nodeId: string): string[] {
+	private getNodeParentFolders(nodeId: string): string[] {
 		const subFolders = ["/"];
 
 		const splittedNodeId = nodeId.split("/");
@@ -389,7 +389,7 @@ export class GraphDataInjector {
 	 * const result = getNodeParentFolder(nodeId);
 	 * // result = "/folder/subfolder"
 	 */
-	getNodeParentFolder(nodeId: string): string {
+	private getNodeParentFolder(nodeId: string): string {
 		const splittedNodeId = nodeId.split("/");
 		const subFoldersSteps = splittedNodeId.slice(0, splittedNodeId.length - 1).filter((e) => e != "");
 

--- a/src/graph/GraphDataInjector.ts
+++ b/src/graph/GraphDataInjector.ts
@@ -13,15 +13,21 @@ const HEADING_NODE_TAG = "f2g_heading_node";
  * Injects folder nodes and heading nodes into the graph data before it is
  * passed to Obsidian's native renderer.
  *
+ * @remarks
  * This class is responsible for:
  * - Enumerating parent folder paths from existing node IDs and inserting a
- *   virtual folder node for each.
- * - Wiring structural links between folders, files, and headings.
+ *   virtual folder node for each path.
+ * - Wiring structural links between folders, files, and headings, and
+ *   registering those links in `StructuralHierarchy`.
  * - Injecting heading nodes derived from each Markdown file's metadata cache.
  * - Filtering out hidden nodes (from `settings.hiddenNodes`) before the data
  *   reaches the renderer.
  * - Triggering the structural hierarchy rebuild and the purge of stale entries
- *   on every setData call.
+ *   on every `setData` call.
+ *
+ * The custom `setData` override is installed once per renderer instance via
+ * `install`. The original function is preserved as
+ * `renderer.originalSetData` so it can be restored on plugin unload.
  */
 export class GraphDataInjector {
 	private app: App;
@@ -36,9 +42,16 @@ export class GraphDataInjector {
 	private folderNodeIds: Set<string> = new Set();
 
 	/** Full set of node IDs present in the last complete graph data, used for
-	 * validating Shift+click targets in the openLinkText wrapper. */
+	 * validating Shift+click targets in the `openLinkText` wrapper. */
 	private allNodeIds: Set<string> = new Set();
 
+	/**
+	 * @param app            Obsidian application instance.
+	 * @param settings       Plugin settings; read for feature flags and `hiddenNodes`.
+	 * @param hierarchy      Structural hierarchy; reset and rebuilt on every setData.
+	 * @param foldingManager Used to purge stale `hiddenNodes` entries.
+	 * @param save           Callback to persist settings when a purge modifies them.
+	 */
 	constructor(
 		app: App,
 		settings: Settings,
@@ -53,12 +66,26 @@ export class GraphDataInjector {
 		this.save = save;
 	}
 
-	/** Returns the set of injected folder node IDs for the last graph data pass. */
+	/**
+	 * Returns the set of injected folder node IDs for the last graph data pass.
+	 *
+	 * @remarks
+	 * Used by `GraphInteractions.wrapOpenLinkText` to identify folder-node
+	 * clicks without relying on the brittle `startsWith("/")` heuristic, which
+	 * could collide with unusual user wikilinks.
+	 */
 	getFolderNodeIds(): Set<string> {
 		return this.folderNodeIds;
 	}
 
-	/** Returns the full set of all node IDs from the last graph data pass. */
+	/**
+	 * Returns the full set of all node IDs from the last graph data pass
+	 * (post-injection, pre-filter).
+	 *
+	 * @remarks
+	 * Used by `GraphInteractions.wrapOpenLinkText` to validate that a
+	 * Shift+clicked node is a known graph node before toggling its fold state.
+	 */
 	getAllNodeIds(): Set<string> {
 		return this.allNodeIds;
 	}
@@ -68,19 +95,22 @@ export class GraphDataInjector {
 	 * `setData` is saved as `renderer.originalSetData` so it can be restored
 	 * on plugin unload.
 	 *
-	 * The override:
-	 * 1. Injects folder nodes (when `settings.showFolderNodes` is true).
-	 * 2. Injects heading nodes (when `settings.showHeadingNodes` is true).
-	 * 3. Purges stale `hiddenNodes` entries against the vault.
-	 * 4. Computes the collapsed set for O(1) frame-time lookups.
-	 * 5. Filters hidden nodes from the data.
-	 * 6. Calls the original `setData`.
-	 * 7. Triggers the prototype patch callback so rendering overrides are
-	 *    applied after the node list is populated.
-	 *
-	 * @param renderer The graph leaf renderer to patch.
+	 * @param renderer       The graph leaf renderer to patch.
 	 * @param onAfterSetData Callback invoked after the original `setData` runs;
-	 *   used by the plugin to apply the node prototype patch.
+	 *   used by the plugin to apply the node prototype patch once the node list
+	 *   is populated.
+	 *
+	 * @remarks
+	 * The override executes in this order on every setData call:
+	 * 1. Clear `folderNodeIds` and reset the structural hierarchy.
+	 * 2. Inject folder nodes (when `settings.showFolderNodes` is `true`).
+	 * 3. Inject heading nodes (when `settings.showHeadingNodes` is `true`).
+	 * 4. Snapshot `allNodeIds` for Shift+click validation.
+	 * 5. Purge stale `hiddenNodes` entries against the vault; save if changed.
+	 * 6. Compute the collapsed set for O(1) frame-time lookups.
+	 * 7. Filter hidden nodes and their links from the data.
+	 * 8. Call the original `setData`.
+	 * 9. Invoke `onAfterSetData` so the prototype patch is (re-)applied.
 	 */
 	install(renderer: LeafRenderer, onAfterSetData: (renderer: LeafRenderer) => void): void {
 		if (renderer.originalSetData == undefined) {
@@ -184,15 +214,21 @@ export class GraphDataInjector {
 	/**
 	 * For a given source node, reads its Markdown headings and inserts a
 	 * heading node per heading, linking each link / embed found in the file
-	 * to the heading it lives under (the closest heading above it). Heading
-	 * node IDs follow Obsidian's wikilink format `path#heading` so a default
-	 * click on the node opens the source note at that section.
+	 * to the heading it lives under (the closest heading above it).
+	 *
+	 * @param data   Mutable graph data object being built during this setData pass.
+	 * @param nodeId Graph node ID of the source Markdown file.
+	 *
+	 * @remarks
+	 * Heading node IDs follow Obsidian's wikilink format `path#heading` so a
+	 * default click on the node opens the source note at that section.
 	 *
 	 * Structural relationships registered here:
 	 * - file → root heading (heading with no ancestor in this file)
 	 * - heading → direct sub-heading
+	 *
 	 * Non-structural links (refs/embeds from a heading to another file) are
-	 * NOT registered.
+	 * added as graph links but NOT registered in `StructuralHierarchy`.
 	 */
 	private injectHeadingNodesForFile(data: RendererData, nodeId: string): void {
 		const file = this.app.metadataCache.getFirstLinkpathDest(nodeId, "");
@@ -255,8 +291,17 @@ export class GraphDataInjector {
 
 	/**
 	 * Returns the heading whose start line is the closest above (or equal to)
-	 * `line`. Headings are assumed to be sorted by position (Obsidian
-	 * guarantees document order).
+	 * `line`.
+	 *
+	 * @param headings Document-ordered array of heading caches from Obsidian.
+	 * @param line     Zero-based line number of the reference position.
+	 * @returns The nearest owning `HeadingCache`, or `null` when the reference
+	 *   appears before the first heading in the file.
+	 *
+	 * @remarks
+	 * Headings are assumed to be sorted by position (Obsidian guarantees
+	 * document order). Iteration stops as soon as a heading whose start line
+	 * exceeds `line` is encountered.
 	 */
 	private findOwningHeading(headings: HeadingCache[], line: number): Nullable<HeadingCache> {
 		let owning: Nullable<HeadingCache> = null;
@@ -274,16 +319,27 @@ export class GraphDataInjector {
 	 * Builds the heading node ID, matching Obsidian's wikilink syntax
 	 * (`path#heading`) so default click handling opens the note at the
 	 * corresponding section.
+	 *
+	 * @param sourceNodeId Graph node ID of the source file (e.g. `folder/note`).
+	 * @param heading      Raw heading text as it appears in the Markdown file.
+	 * @returns Heading node ID in the form `sourceNodeId#heading`.
 	 */
 	buildHeadingNodeId(sourceNodeId: string, heading: string): string {
 		return `${sourceNodeId}#${heading}`;
 	}
 
 	/**
-	 * Resolves a destination TFile to its corresponding graph node ID. The
-	 * graph stores nodes either by their full path or by their basename for
-	 * ghost links, so both candidates are tried and the path is used as
-	 * fallback.
+	 * Resolves a destination `TFile` to its corresponding graph node ID.
+	 *
+	 * @param data Graph data object containing the current node map.
+	 * @param dest The destination file to look up.
+	 * @returns The matching graph node ID, or `dest.path` as a fallback when
+	 *   no exact match is found in the node map.
+	 *
+	 * @remarks
+	 * The graph stores nodes either by their full path (e.g. `folder/note.md`)
+	 * or by their basename for ghost links (e.g. `note`), so both candidates
+	 * are tried before falling back to the path.
 	 */
 	private resolveGraphNodeId(data: RendererData, dest: TFile): Nullable<string> {
 		if (data.nodes[dest.path]) return dest.path;
@@ -296,6 +352,10 @@ export class GraphDataInjector {
 	/**
 	 * Returns each ancestor folder path of `nodeId` as a `/`-prefixed string,
 	 * including the vault root `/`.
+	 *
+	 * @param nodeId Graph node ID of the file or folder.
+	 * @returns Array of `/`-prefixed folder paths from root to the immediate
+	 *   parent, in ascending depth order.
 	 *
 	 * @example
 	 * const nodeId = "folder/subfolder/file.md";
@@ -320,6 +380,9 @@ export class GraphDataInjector {
 	/**
 	 * Returns the direct parent folder path of `nodeId` as a `/`-prefixed
 	 * string. The vault root `/` is its own parent.
+	 *
+	 * @param nodeId Graph node ID of the file or folder.
+	 * @returns The `/`-prefixed parent folder path.
 	 *
 	 * @example
 	 * const nodeId = "folder/subfolder/file.md";

--- a/src/graph/GraphInteractions.ts
+++ b/src/graph/GraphInteractions.ts
@@ -3,11 +3,25 @@ import { GraphLeafWithCustomRenderer } from "interfaces/GraphLeafWithCustomRende
 import { Nullable } from "types/Nullable";
 
 /**
- * Manages all DOM-level interactions for the graph: Shift key tracking, the
- * `openLinkText` wrapper that intercepts folder-node clicks and fold-toggle
- * gestures, folder revelation in the file explorer, and the per-leaf DOM
- * `contextmenu` suppressor that swallows the native context menu after a
- * Shift+right-click on a node with hidden descendants.
+ * Manages all DOM-level interactions for the graph view.
+ *
+ * @remarks
+ * Responsibilities:
+ * - **Shift key tracking** — capture-phase `keydown`/`keyup`/`blur` listeners
+ *   on `window` maintain a boolean that is consulted by the `openLinkText`
+ *   wrapper.
+ * - **`openLinkText` wrapper** — intercepts folder-node clicks (to reveal the
+ *   folder in the file explorer) and Shift+left-click on any graph node (to
+ *   toggle fold state) before the native navigation runs.
+ * - **Folder revelation** — delegates to the internal `file-explorer` plugin
+ *   instance; falls back silently when the undocumented API is unavailable.
+ * - **Context-menu suppressor** — installs a per-leaf capture-phase DOM
+ *   `contextmenu` listener that swallows the native context menu right after
+ *   the PIXI `rightdown` wrapper sets `suppressNextContextMenu`, preventing
+ *   the OS context menu from appearing on Shift+right-click.
+ *
+ * Listeners are cleaned up on unload via `unregisterKeyListeners` and
+ * `abortAllContextMenuSuppressors`.
  */
 export class GraphInteractions {
 	private app: App;
@@ -16,29 +30,34 @@ export class GraphInteractions {
 	private handleFoldToggle: (nodeId: string) => void;
 
 	/** True while the Shift key is held down. Tracked via capture-phase
-	 * keydown/keyup on window, with a blur-reset to handle cases where keyup
-	 * is missed. */
+	 * keydown/keyup on window, with a blur-reset to handle cases where the
+	 * keyup event is missed (e.g. when the window loses focus while Shift is
+	 * held). */
 	private shiftHeld = false;
 
-	/** Set to true by the PIXI rightdown wrapper when it swallows a
-	 * Shift+right-click with hidden descendants, so the subsequent DOM
-	 * `contextmenu` event can be suppressed without any coordinate
-	 * hit-testing. Reset immediately after consumption. */
+	/** Set to `true` by the PIXI `rightdown` wrapper (in
+	 * `NodePrototypePatcher`) when it swallows a Shift+right-click with hidden
+	 * descendants, so the subsequent DOM `contextmenu` event can be suppressed
+	 * without any coordinate hit-testing. Reset immediately after consumption
+	 * by the DOM listener. */
 	private suppressNextContextMenu = false;
 
 	/** Original `workspace.openLinkText` saved when we wrap it, so we can
 	 * restore on unload. */
 	private originalOpenLinkText: Nullable<Workspace["openLinkText"]> = null;
 
-	/** WeakMap from a leaf's containerEl to its AbortController, used for
-	 * the DOM contextmenu suppression listener. */
+	/** WeakMap from a leaf's `containerEl` to its `AbortController`, used to
+	 * ensure at most one DOM `contextmenu` suppressor is active per container.
+	 * A `WeakMap` is used so containers that are garbage-collected do not keep
+	 * controllers alive. */
 	private contextMenuAbortControllers: WeakMap<HTMLElement, AbortController> = new WeakMap();
 
-	/** Flat set of all active AbortControllers so onunload can abort them all. */
+	/** Flat set of all active `AbortController`s so `onunload` can abort them
+	 * all in one sweep. */
 	private activeAbortControllers: Set<AbortController> = new Set();
 
 	/** Arrow-function handlers stored so the same references can be passed to
-	 * removeEventListener on unload. */
+	 * `removeEventListener` on unload. */
 	private onKeyDown = (e: KeyboardEvent): void => {
 		if (e.key === "Shift") this.shiftHeld = true;
 	};
@@ -49,6 +68,15 @@ export class GraphInteractions {
 		this.shiftHeld = false;
 	};
 
+	/**
+	 * @param app               Obsidian application instance.
+	 * @param getFolderNodeIds  Returns the set of currently injected folder
+	 *   node IDs; consulted by the `openLinkText` wrapper.
+	 * @param getAllNodeIds      Returns the full set of node IDs from the last
+	 *   `setData` pass; used to validate Shift+click targets.
+	 * @param handleFoldToggle  Callback invoked when a Shift+left-click on a
+	 *   valid graph node is detected.
+	 */
 	constructor(
 		app: App,
 		getFolderNodeIds: () => Set<string>,
@@ -61,20 +89,40 @@ export class GraphInteractions {
 		this.handleFoldToggle = handleFoldToggle;
 	}
 
-	/** Returns the current value of the suppress-context-menu flag. */
+	/**
+	 * Returns the current value of the suppress-context-menu flag.
+	 *
+	 * @remarks
+	 * Read by the DOM `contextmenu` listener installed in
+	 * `installContextMenuSuppressor`.
+	 */
 	getSuppressNextContextMenu(): boolean {
 		return this.suppressNextContextMenu;
 	}
 
-	/** Sets the suppress-context-menu flag. Called by `NodePrototypePatcher`
-	 * when a Shift+right-click gesture is swallowed. */
+	/**
+	 * Sets the suppress-context-menu flag.
+	 *
+	 * @param value `true` to arm the suppressor; `false` to reset it.
+	 *
+	 * @remarks
+	 * Called by `NodePrototypePatcher` when a Shift+right-click gesture on a
+	 * node with hidden descendants is swallowed by the PIXI `rightdown`
+	 * wrapper.
+	 */
 	setSuppressNextContextMenu(value: boolean): void {
 		this.suppressNextContextMenu = value;
 	}
 
 	/**
-	 * Registers global Shift key tracking listeners on `window`. Must be
-	 * called during plugin load; paired with `unregisterKeyListeners`.
+	 * Registers global Shift key tracking listeners on `window`.
+	 *
+	 * @remarks
+	 * All three listeners use capture phase (`true`) so they fire before any
+	 * element-level handler. The `blur` listener resets `shiftHeld` when the
+	 * window loses focus to prevent the Shift state from getting stuck.
+	 *
+	 * Must be called during plugin load; paired with `unregisterKeyListeners`.
 	 */
 	registerKeyListeners(): void {
 		window.addEventListener("keydown", this.onKeyDown, true);
@@ -84,7 +132,7 @@ export class GraphInteractions {
 
 	/**
 	 * Removes the global Shift key tracking listeners installed by
-	 * `registerKeyListeners`.
+	 * `registerKeyListeners`. Must be called on plugin unload.
 	 */
 	unregisterKeyListeners(): void {
 		window.removeEventListener("keydown", this.onKeyDown, true);
@@ -93,8 +141,14 @@ export class GraphInteractions {
 	}
 
 	/**
-	 * Aborts all active contextmenu suppression controllers and clears the
+	 * Aborts all active context-menu suppression controllers and clears the
 	 * tracking sets. Called during plugin unload.
+	 *
+	 * @remarks
+	 * After this call the `contextMenuAbortControllers` WeakMap may still hold
+	 * entries for containers that have not been garbage-collected, but those
+	 * controllers are already aborted and their listeners are detached by the
+	 * AbortSignal mechanism.
 	 */
 	abortAllContextMenuSuppressors(): void {
 		this.activeAbortControllers.forEach((controller) => controller.abort());
@@ -104,9 +158,17 @@ export class GraphInteractions {
 	/**
 	 * Wraps `workspace.openLinkText` so that clicks on folder nodes reveal the
 	 * corresponding folder in the file explorer instead of failing to resolve a
-	 * non-existent file. The wrapper only intercepts linktexts that match a
-	 * currently-injected folder node ID, so regular wikilink clicks are
-	 * unaffected.
+	 * non-existent file, and so that Shift+left-click on any graph node toggles
+	 * its fold state instead of navigating.
+	 *
+	 * @remarks
+	 * The wrapper only intercepts linktexts that match a currently-injected
+	 * folder node ID, so regular wikilink clicks are unaffected.
+	 *
+	 * The Shift+fold gate is guarded by the most recent leaf being a graph
+	 * view: clicking a graph node activates its leaf before `openLinkText`
+	 * fires, while a Shift+click on an editor wikilink keeps the editor leaf
+	 * active — so editor links are never accidentally swallowed.
 	 */
 	wrapOpenLinkText(): void {
 		const workspace = this.app.workspace;
@@ -139,7 +201,8 @@ export class GraphInteractions {
 	}
 
 	/**
-	 * Restores the original `workspace.openLinkText`.
+	 * Restores the original `workspace.openLinkText` that was saved by
+	 * `wrapOpenLinkText`. A no-op when the wrapper was never installed.
 	 */
 	unwrapOpenLinkText(): void {
 		if (!this.originalOpenLinkText) return;
@@ -149,9 +212,17 @@ export class GraphInteractions {
 
 	/**
 	 * Reveals the folder backing a folder node in Obsidian's file explorer.
-	 * Folder node IDs use a leading `/` and a `/`-rooted path (e.g.
-	 * `/work/notes`); the vault stores paths without the leading slash, and
-	 * the vault root is `""`.
+	 *
+	 * @param folderNodeId A folder node ID in the form `"/"` (vault root) or
+	 *   `"/path/to/folder"`.
+	 *
+	 * @remarks
+	 * Folder node IDs use a leading `/` and a `/`-rooted path; the vault stores
+	 * paths without the leading slash, and the vault root is `""`.
+	 *
+	 * `revealInFolder` is exposed by the internal `file-explorer` plugin
+	 * instance and is not part of Obsidian's public API — the call falls back
+	 * silently when the method is absent.
 	 */
 	private revealFolderInExplorer(folderNodeId: string): void {
 		const vaultPath = folderNodeId === "/" ? "" : folderNodeId.slice(1);
@@ -188,13 +259,21 @@ export class GraphInteractions {
 	/**
 	 * Installs a capture-phase DOM `contextmenu` listener on the graph view
 	 * container that suppresses the native context menu right after the PIXI
-	 * rightdown wrapper swallowed a Shift+right-click. No coordinate
-	 * hit-testing is involved: the PIXI wrapper sets `suppressNextContextMenu`
-	 * and this listener merely consumes the flag.
+	 * `rightdown` wrapper swallowed a Shift+right-click.
 	 *
-	 * One listener per container: any previous controller for the same
-	 * container is aborted before registering, so repeated `refreshGraphLeaves`
-	 * calls never stack listeners.
+	 * @param leaf The graph leaf whose container should receive the listener.
+	 *
+	 * @remarks
+	 * No coordinate hit-testing is involved: the PIXI wrapper sets
+	 * `suppressNextContextMenu` and this listener merely consumes the flag.
+	 *
+	 * One listener per container is enforced: any previous controller for the
+	 * same container is aborted before a new one is registered, so repeated
+	 * `refreshGraphLeaves` calls never stack listeners. The listener is
+	 * installed AFTER `unload/load` so it is never orphaned by a view rebuild.
+	 *
+	 * The `AbortController` pattern is used instead of `removeEventListener`
+	 * to guarantee clean-up even if the container element is replaced.
 	 */
 	installContextMenuSuppressor(leaf: GraphLeafWithCustomRenderer): void {
 		const containerEl = leaf.view.containerEl;

--- a/src/graph/GraphInteractions.ts
+++ b/src/graph/GraphInteractions.ts
@@ -1,0 +1,225 @@
+import { App, OpenViewState, PaneType, TFolder, Workspace } from "obsidian";
+import { GraphLeafWithCustomRenderer } from "interfaces/GraphLeafWithCustomRenderer";
+import { Nullable } from "types/Nullable";
+
+/**
+ * Manages all DOM-level interactions for the graph: Shift key tracking, the
+ * `openLinkText` wrapper that intercepts folder-node clicks and fold-toggle
+ * gestures, folder revelation in the file explorer, and the per-leaf DOM
+ * `contextmenu` suppressor that swallows the native context menu after a
+ * Shift+right-click on a node with hidden descendants.
+ */
+export class GraphInteractions {
+	private app: App;
+	private getFolderNodeIds: () => Set<string>;
+	private getAllNodeIds: () => Set<string>;
+	private handleFoldToggle: (nodeId: string) => void;
+
+	/** True while the Shift key is held down. Tracked via capture-phase
+	 * keydown/keyup on window, with a blur-reset to handle cases where keyup
+	 * is missed. */
+	private shiftHeld = false;
+
+	/** Set to true by the PIXI rightdown wrapper when it swallows a
+	 * Shift+right-click with hidden descendants, so the subsequent DOM
+	 * `contextmenu` event can be suppressed without any coordinate
+	 * hit-testing. Reset immediately after consumption. */
+	private suppressNextContextMenu = false;
+
+	/** Original `workspace.openLinkText` saved when we wrap it, so we can
+	 * restore on unload. */
+	private originalOpenLinkText: Nullable<Workspace["openLinkText"]> = null;
+
+	/** WeakMap from a leaf's containerEl to its AbortController, used for
+	 * the DOM contextmenu suppression listener. */
+	private contextMenuAbortControllers: WeakMap<HTMLElement, AbortController> = new WeakMap();
+
+	/** Flat set of all active AbortControllers so onunload can abort them all. */
+	private activeAbortControllers: Set<AbortController> = new Set();
+
+	/** Arrow-function handlers stored so the same references can be passed to
+	 * removeEventListener on unload. */
+	private onKeyDown = (e: KeyboardEvent): void => {
+		if (e.key === "Shift") this.shiftHeld = true;
+	};
+	private onKeyUp = (e: KeyboardEvent): void => {
+		if (e.key === "Shift") this.shiftHeld = false;
+	};
+	private onBlur = (): void => {
+		this.shiftHeld = false;
+	};
+
+	constructor(
+		app: App,
+		getFolderNodeIds: () => Set<string>,
+		getAllNodeIds: () => Set<string>,
+		handleFoldToggle: (nodeId: string) => void,
+	) {
+		this.app = app;
+		this.getFolderNodeIds = getFolderNodeIds;
+		this.getAllNodeIds = getAllNodeIds;
+		this.handleFoldToggle = handleFoldToggle;
+	}
+
+	/** Returns the current value of the suppress-context-menu flag. */
+	getSuppressNextContextMenu(): boolean {
+		return this.suppressNextContextMenu;
+	}
+
+	/** Sets the suppress-context-menu flag. Called by `NodePrototypePatcher`
+	 * when a Shift+right-click gesture is swallowed. */
+	setSuppressNextContextMenu(value: boolean): void {
+		this.suppressNextContextMenu = value;
+	}
+
+	/**
+	 * Registers global Shift key tracking listeners on `window`. Must be
+	 * called during plugin load; paired with `unregisterKeyListeners`.
+	 */
+	registerKeyListeners(): void {
+		window.addEventListener("keydown", this.onKeyDown, true);
+		window.addEventListener("keyup", this.onKeyUp, true);
+		window.addEventListener("blur", this.onBlur, true);
+	}
+
+	/**
+	 * Removes the global Shift key tracking listeners installed by
+	 * `registerKeyListeners`.
+	 */
+	unregisterKeyListeners(): void {
+		window.removeEventListener("keydown", this.onKeyDown, true);
+		window.removeEventListener("keyup", this.onKeyUp, true);
+		window.removeEventListener("blur", this.onBlur, true);
+	}
+
+	/**
+	 * Aborts all active contextmenu suppression controllers and clears the
+	 * tracking sets. Called during plugin unload.
+	 */
+	abortAllContextMenuSuppressors(): void {
+		this.activeAbortControllers.forEach((controller) => controller.abort());
+		this.activeAbortControllers.clear();
+	}
+
+	/**
+	 * Wraps `workspace.openLinkText` so that clicks on folder nodes reveal the
+	 * corresponding folder in the file explorer instead of failing to resolve a
+	 * non-existent file. The wrapper only intercepts linktexts that match a
+	 * currently-injected folder node ID, so regular wikilink clicks are
+	 * unaffected.
+	 */
+	wrapOpenLinkText(): void {
+		const workspace = this.app.workspace;
+		this.originalOpenLinkText = workspace.openLinkText.bind(workspace);
+
+		workspace.openLinkText = (
+			linktext: string,
+			sourcePath: string,
+			newLeaf?: PaneType | boolean,
+			openViewState?: OpenViewState,
+		): Promise<void> => {
+			// Shift+left-click on a graph node → toggle its fold state instead of
+			// navigating. Guarded on the most recent leaf being a graph view:
+			// clicking a node activates its leaf before openLinkText fires, while
+			// a Shift+click on an editor wikilink keeps the editor leaf active —
+			// so editor links are never swallowed.
+			const activeIsGraph =
+				this.app.workspace.getMostRecentLeaf()?.view?.getViewType?.() === "graph";
+			if (this.shiftHeld && activeIsGraph && this.getAllNodeIds().has(linktext)) {
+				this.handleFoldToggle(linktext);
+				return Promise.resolve();
+			}
+
+			if (this.getFolderNodeIds().has(linktext)) {
+				this.revealFolderInExplorer(linktext);
+				return Promise.resolve();
+			}
+			return this.originalOpenLinkText!(linktext, sourcePath, newLeaf, openViewState);
+		};
+	}
+
+	/**
+	 * Restores the original `workspace.openLinkText`.
+	 */
+	unwrapOpenLinkText(): void {
+		if (!this.originalOpenLinkText) return;
+		this.app.workspace.openLinkText = this.originalOpenLinkText;
+		this.originalOpenLinkText = null;
+	}
+
+	/**
+	 * Reveals the folder backing a folder node in Obsidian's file explorer.
+	 * Folder node IDs use a leading `/` and a `/`-rooted path (e.g.
+	 * `/work/notes`); the vault stores paths without the leading slash, and
+	 * the vault root is `""`.
+	 */
+	private revealFolderInExplorer(folderNodeId: string): void {
+		const vaultPath = folderNodeId === "/" ? "" : folderNodeId.slice(1);
+		const folder: Nullable<TFolder> =
+			vaultPath === ""
+				? this.app.vault.getRoot()
+				: (this.app.vault.getAbstractFileByPath(vaultPath) as Nullable<TFolder>);
+		if (!folder) return;
+
+		// Make sure a file-explorer leaf exists and is in focus.
+		let leaf = this.app.workspace.getLeavesOfType("file-explorer")[0];
+		if (!leaf) {
+			const leftLeaf = this.app.workspace.getLeftLeaf(false);
+			if (leftLeaf) {
+				leftLeaf.setViewState({ type: "file-explorer" });
+				leaf = leftLeaf;
+			}
+		}
+		if (!leaf) return;
+		this.app.workspace.revealLeaf(leaf);
+
+		// `revealInFolder` is exposed by the internal `file-explorer` plugin
+		// instance. Not part of the public API — fall back silently if it ever
+		// moves.
+		const fileExplorerInstance = (this.app as unknown as {
+			internalPlugins?: {
+				getPluginById?: (id: string) => { instance?: { revealInFolder?: (f: TFolder) => void } };
+			};
+		}).internalPlugins?.getPluginById?.("file-explorer")?.instance;
+
+		fileExplorerInstance?.revealInFolder?.(folder);
+	}
+
+	/**
+	 * Installs a capture-phase DOM `contextmenu` listener on the graph view
+	 * container that suppresses the native context menu right after the PIXI
+	 * rightdown wrapper swallowed a Shift+right-click. No coordinate
+	 * hit-testing is involved: the PIXI wrapper sets `suppressNextContextMenu`
+	 * and this listener merely consumes the flag.
+	 *
+	 * One listener per container: any previous controller for the same
+	 * container is aborted before registering, so repeated `refreshGraphLeaves`
+	 * calls never stack listeners.
+	 */
+	installContextMenuSuppressor(leaf: GraphLeafWithCustomRenderer): void {
+		const containerEl = leaf.view.containerEl;
+
+		const existing = this.contextMenuAbortControllers.get(containerEl);
+		if (existing) {
+			existing.abort();
+			this.activeAbortControllers.delete(existing);
+		}
+
+		const controller = new AbortController();
+		this.contextMenuAbortControllers.set(containerEl, controller);
+		this.activeAbortControllers.add(controller);
+
+		containerEl.addEventListener(
+			"contextmenu",
+			(event: MouseEvent) => {
+				if (this.suppressNextContextMenu) {
+					event.preventDefault();
+					event.stopPropagation();
+					this.suppressNextContextMenu = false;
+				}
+				// No flag — let the event through so the native context menu appears.
+			},
+			{ capture: true, signal: controller.signal },
+		);
+	}
+}

--- a/src/graph/NodePrototypePatcher.ts
+++ b/src/graph/NodePrototypePatcher.ts
@@ -78,6 +78,16 @@ export class NodePrototypePatcher {
 	 *
 	 * A no-op when `renderer.nodes` is empty or the prototype already carries
 	 * the `__f2gPatched` flag.
+	 *
+	 * @example
+	 * // Half-disc orientation: the rounded side faces the structural parent.
+	 * // If the collapsed node sits at (100, 200) and its parent is at (100, 50),
+	 * // the parent is directly above → angle = Math.atan2(50 - 200, 100 - 100) = -π/2
+	 * // Arc drawn from -π/2 − π/2 = -π  to  -π/2 + π/2 = 0  (upper half-disc).
+	 * //
+	 * // If the parent is to the right at (300, 200):
+	 * // angle = Math.atan2(200 - 200, 300 - 100) = 0
+	 * // Arc drawn from -π/2  to  π/2  (right-facing half-disc).
 	 */
 	patch(renderer: LeafRenderer): void {
 		if (renderer.nodes.length === 0) return;
@@ -407,6 +417,20 @@ export class NodePrototypePatcher {
 	 * Uses `indexOf` (first `#`) so that headings whose text itself contains
 	 * `#` characters are handled consistently — such IDs are a known degraded
 	 * case where the heading text will be truncated at the second `#`.
+	 *
+	 * @example
+	 * const label = extractHeadingFromNodeId("docs/guide#Getting Started");
+	 * // label = "Getting Started"
+	 *
+	 * @example
+	 * // Degraded case: heading text contains a `#` character.
+	 * const label = extractHeadingFromNodeId("notes/faq#What is C#?");
+	 * // label = "What is C"  — truncated at the second `#`
+	 *
+	 * @example
+	 * // No `#` present — full nodeId returned (should not occur for heading nodes).
+	 * const label = extractHeadingFromNodeId("docs/guide");
+	 * // label = "docs/guide"
 	 */
 	private extractHeadingFromNodeId(nodeId: string): string {
 		const idx = nodeId.indexOf("#");

--- a/src/graph/NodePrototypePatcher.ts
+++ b/src/graph/NodePrototypePatcher.ts
@@ -9,17 +9,23 @@ const HEADING_NODE_TAG = "f2g_heading_node";
  * Patches and restores the Node class prototype shared by all graph node
  * instances across all leaves.
  *
- * Because the prototype is shared, the patch must NOT capture any per-leaf
- * state (renderer reference, leaf ID, …). All data is accessed through the
- * injected `settings` and `hierarchy` references, and through per-instance
- * properties (`this.id`, `this.renderer`, …) read at call time.
+ * @remarks
+ * Because the prototype is shared across ALL graph leaves, the patch must NOT
+ * capture any per-leaf or per-renderer state. All data is accessed through:
+ * - The injected `settings` and `hierarchy` references (shared singletons).
+ * - Per-instance properties (`this.id`, `this.renderer`, `this.circle`, …)
+ *   read at call time inside the patched methods.
  *
  * The patch covers:
  * - `getFillColor` — returns the configured colour for folder / heading nodes.
  * - `getDisplayText` — strips the file-path prefix from heading node labels.
- * - Render method (`render` | `draw` | `updateGraphics`) — wraps PIXI circle
- *   listeners once per instance to intercept Shift+right-click, and redraws
- *   collapsed nodes as a half-disc each frame.
+ * - Render method (`render` | `draw` | `updateGraphics`, whichever is present
+ *   in the current Obsidian build) — wraps PIXI circle listeners once per
+ *   node instance to intercept Shift+right-click, and redraws collapsed nodes
+ *   as a half-disc on every frame.
+ *
+ * `patch` is idempotent: a second call on an already-patched prototype is a
+ * no-op, guarded by the `__f2gPatched` flag.
  */
 export class NodePrototypePatcher {
 	private settings: Settings;
@@ -28,6 +34,19 @@ export class NodePrototypePatcher {
 	private setSuppressNextContextMenu: (value: boolean) => void;
 	private getSuppressNextContextMenu: () => boolean;
 
+	/**
+	 * @param settings                    Plugin settings; read for node colours.
+	 * @param hierarchy                   Structural hierarchy; queried for
+	 *   `isCollapsed`, `getParent`, and `hasHiddenDescendant` at render time.
+	 * @param handleRecursiveUnfold       Callback that triggers a full subtree
+	 *   unfold when Shift+right-click is detected on a node with hidden
+	 *   descendants.
+	 * @param getSuppressNextContextMenu  Returns the current value of the
+	 *   suppress-context-menu flag, set by the PIXI rightdown wrapper and
+	 *   consumed by the DOM `contextmenu` listener.
+	 * @param setSuppressNextContextMenu  Sets the suppress-context-menu flag.
+	 *   Called by the PIXI rightdown wrapper when swallowing a gesture.
+	 */
 	constructor(
 		settings: Settings,
 		hierarchy: StructuralHierarchy,
@@ -44,14 +63,21 @@ export class NodePrototypePatcher {
 
 	/**
 	 * Patches the Node class prototype so every node instance — current and
-	 * future — returns the configured color for folder nodes, the configured
-	 * color for heading nodes, (best effort) renders collapsed nodes as a
-	 * semi-circle, and intercepts Shift+right-click to trigger recursive
-	 * unfold.
+	 * future — returns the configured colour for folder / heading nodes,
+	 * renders collapsed nodes as a semi-circle, and intercepts
+	 * Shift+right-click to trigger recursive unfold.
 	 *
-	 * Patching the prototype (rather than each instance) ensures the override
-	 * survives node recreations triggered by Obsidian without going through
-	 * our custom `setData`.
+	 * @param renderer Any mounted graph renderer; used only to access the first
+	 *   node instance and obtain its prototype. The renderer reference is NOT
+	 *   captured by the patch.
+	 *
+	 * @remarks
+	 * Patching the prototype (rather than each instance) ensures the overrides
+	 * survive node recreations triggered by Obsidian without going through our
+	 * custom `setData`.
+	 *
+	 * A no-op when `renderer.nodes` is empty or the prototype already carries
+	 * the `__f2gPatched` flag.
 	 */
 	patch(renderer: LeafRenderer): void {
 		if (renderer.nodes.length === 0) return;
@@ -91,9 +117,9 @@ export class NodePrototypePatcher {
 		// Patch the node render method (its name varies across Obsidian builds)
 		// so that, once per node instance, the PIXI listeners of the node circle
 		// are wrapped to intercept Shift+right-click. Obsidian registers its own
-		// circle listeners BEFORE ours, so simply adding another listener could
-		// not prevent the native behaviour — the existing listeners are detached
-		// and re-invoked conditionally instead.
+		// circle listeners (which open the native context menu) BEFORE ours, so
+		// simply adding another listener could not prevent the native behaviour —
+		// the existing listeners are detached and re-invoked conditionally instead.
 		const renderMethodName = (["render", "draw", "updateGraphics"] as const).find(
 			(name) => typeof proto[name] === "function",
 		) as string | undefined;
@@ -203,8 +229,11 @@ export class NodePrototypePatcher {
 					try {
 						// Measure the native base radius AND centre from the local geometry on
 						// first encounter (before we clear it). Both are cached per-instance.
+						//
 						// Obsidian draws the circle at a large local radius (~100) and uses the
-						// DisplayObject scale for sizing, so getSize() is wrong here.
+						// DisplayObject scale for sizing, so `getSize()` returns the wrong
+						// value here — we must read local geometry instead.
+						//
 						// The centre must be captured because PIXI geometry is not necessarily
 						// centred on (0, 0) — drawing at (0, 0) would appear shifted by one
 						// radius. Fallbacks: radius=100, centre=(0, 0).
@@ -275,8 +304,8 @@ export class NodePrototypePatcher {
 					}
 				} else if (this.__f2gHalfDrawn) {
 					// ── TRANSITION: just unfolded ── restore the full circle once. Obsidian
-					// does not redraw the circle geometry on its own, so a custom drawing
-					// persists until we replace it ourselves.
+					// does not redraw the circle geometry on its own when a node changes
+					// state, so a custom drawing persists until we replace it explicitly.
 					try {
 						const baseRadius: number = this.__f2gBaseRadius ?? 100;
 						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
@@ -307,7 +336,14 @@ export class NodePrototypePatcher {
 
 	/**
 	 * Restores the original `getFillColor`, `getDisplayText`, and render method
-	 * on the Node prototype. Called on plugin unload.
+	 * on the Node prototype.
+	 *
+	 * @param renderer Any mounted graph renderer; used only to access the node
+	 *   prototype. The renderer reference is NOT stored.
+	 *
+	 * @remarks
+	 * Called on plugin unload. A no-op when the prototype does not carry the
+	 * `__f2gPatched` flag (e.g. when the renderer had no nodes at patch time).
 	 */
 	unpatch(renderer: LeafRenderer): void {
 		if (renderer.nodes.length === 0) return;
@@ -337,14 +373,20 @@ export class NodePrototypePatcher {
 
 	/**
 	 * Converts a CSS hex colour string to the 24-bit integer format used by
-	 * Obsidian's graph renderer (and PIXI). The colour is stored as hex and the
-	 * renderer expects the concatenation of the 8-bit binary values of each
-	 * RGB channel.
+	 * Obsidian's graph renderer (and PIXI tint).
+	 *
+	 * @param hexColor A 7-character CSS hex colour string (e.g. `"#5c8af5"`).
+	 * @returns The colour as a 24-bit integer whose bits are the concatenation
+	 *   of the 8-bit binary values of the R, G, and B channels.
+	 *
+	 * @remarks
+	 * Obsidian's renderer stores per-node colours as plain JavaScript numbers
+	 * in the same format used by PIXI `tint` values.
 	 *
 	 * @example
-	 * const color = "#001100"; // (00000000 00010001 00000000)
+	 * const color = "#001100"; // R=0x00, G=0x11, B=0x00
 	 * const result = getColorNumber(color);
-	 * // result = 4352
+	 * // result = 0x001100 = 4352
 	 */
 	getColorNumber(hexColor: string): number {
 		const r = parseInt(hexColor.substring(1, 3), 16).toString(2).padStart(8, "0");
@@ -355,10 +397,16 @@ export class NodePrototypePatcher {
 	}
 
 	/**
-	 * Extracts the heading portion of a heading node ID (`path#heading` →
-	 * `heading`). Uses `indexOf` (first `#`) so that headings whose text
-	 * itself contains `#` are handled consistently — such IDs are a known
-	 * degraded case. Falls back to the full ID when no `#` is present.
+	 * Extracts the heading portion of a heading node ID.
+	 *
+	 * @param nodeId A heading node ID in the form `path#heading`.
+	 * @returns The heading text after the first `#`, or the full `nodeId` when
+	 *   no `#` is present.
+	 *
+	 * @remarks
+	 * Uses `indexOf` (first `#`) so that headings whose text itself contains
+	 * `#` characters are handled consistently — such IDs are a known degraded
+	 * case where the heading text will be truncated at the second `#`.
 	 */
 	extractHeadingFromNodeId(nodeId: string): string {
 		const idx = nodeId.indexOf("#");

--- a/src/graph/NodePrototypePatcher.ts
+++ b/src/graph/NodePrototypePatcher.ts
@@ -388,7 +388,7 @@ export class NodePrototypePatcher {
 	 * const result = getColorNumber(color);
 	 * // result = 0x001100 = 4352
 	 */
-	getColorNumber(hexColor: string): number {
+	private getColorNumber(hexColor: string): number {
 		const r = parseInt(hexColor.substring(1, 3), 16).toString(2).padStart(8, "0");
 		const g = parseInt(hexColor.substring(3, 5), 16).toString(2).padStart(8, "0");
 		const b = parseInt(hexColor.substring(5, 7), 16).toString(2).padStart(8, "0");
@@ -408,7 +408,7 @@ export class NodePrototypePatcher {
 	 * `#` characters are handled consistently — such IDs are a known degraded
 	 * case where the heading text will be truncated at the second `#`.
 	 */
-	extractHeadingFromNodeId(nodeId: string): string {
+	private extractHeadingFromNodeId(nodeId: string): string {
 		const idx = nodeId.indexOf("#");
 		return idx >= 0 ? nodeId.slice(idx + 1) : nodeId;
 	}

--- a/src/graph/NodePrototypePatcher.ts
+++ b/src/graph/NodePrototypePatcher.ts
@@ -1,0 +1,367 @@
+import { LeafRenderer } from "interfaces/LeafRenderer";
+import { Settings } from "interfaces/Settings";
+import { StructuralHierarchy } from "graph/StructuralHierarchy";
+
+const FOLDER_NODE_TAG = "f2g_node";
+const HEADING_NODE_TAG = "f2g_heading_node";
+
+/**
+ * Patches and restores the Node class prototype shared by all graph node
+ * instances across all leaves.
+ *
+ * Because the prototype is shared, the patch must NOT capture any per-leaf
+ * state (renderer reference, leaf ID, …). All data is accessed through the
+ * injected `settings` and `hierarchy` references, and through per-instance
+ * properties (`this.id`, `this.renderer`, …) read at call time.
+ *
+ * The patch covers:
+ * - `getFillColor` — returns the configured colour for folder / heading nodes.
+ * - `getDisplayText` — strips the file-path prefix from heading node labels.
+ * - Render method (`render` | `draw` | `updateGraphics`) — wraps PIXI circle
+ *   listeners once per instance to intercept Shift+right-click, and redraws
+ *   collapsed nodes as a half-disc each frame.
+ */
+export class NodePrototypePatcher {
+	private settings: Settings;
+	private hierarchy: StructuralHierarchy;
+	private handleRecursiveUnfold: (nodeId: string) => void;
+	private setSuppressNextContextMenu: (value: boolean) => void;
+	private getSuppressNextContextMenu: () => boolean;
+
+	constructor(
+		settings: Settings,
+		hierarchy: StructuralHierarchy,
+		handleRecursiveUnfold: (nodeId: string) => void,
+		getSuppressNextContextMenu: () => boolean,
+		setSuppressNextContextMenu: (value: boolean) => void,
+	) {
+		this.settings = settings;
+		this.hierarchy = hierarchy;
+		this.handleRecursiveUnfold = handleRecursiveUnfold;
+		this.getSuppressNextContextMenu = getSuppressNextContextMenu;
+		this.setSuppressNextContextMenu = setSuppressNextContextMenu;
+	}
+
+	/**
+	 * Patches the Node class prototype so every node instance — current and
+	 * future — returns the configured color for folder nodes, the configured
+	 * color for heading nodes, (best effort) renders collapsed nodes as a
+	 * semi-circle, and intercepts Shift+right-click to trigger recursive
+	 * unfold.
+	 *
+	 * Patching the prototype (rather than each instance) ensures the override
+	 * survives node recreations triggered by Obsidian without going through
+	 * our custom `setData`.
+	 */
+	patch(renderer: LeafRenderer): void {
+		if (renderer.nodes.length === 0) return;
+
+		const proto = Object.getPrototypeOf(renderer.nodes[0]);
+		if (proto.__f2gPatched) return;
+
+		const originalGetFillColor = proto.getFillColor;
+		const patcher = this;
+
+		proto.__f2gOriginalGetFillColor = originalGetFillColor;
+		proto.getFillColor = function () {
+			if (this.type === FOLDER_NODE_TAG) {
+				return { a: 1, rgb: patcher.getColorNumber(patcher.settings.nodeColor) };
+			}
+			if (this.type === HEADING_NODE_TAG) {
+				return { a: 1, rgb: patcher.getColorNumber(patcher.settings.headingNodeColor) };
+			}
+			return originalGetFillColor.call(this);
+		};
+
+		// Heading nodes use the wikilink syntax `path#heading` as their ID so
+		// the native click handler resolves to the right section, but we want
+		// the label to show only the heading text. Override `getDisplayText`
+		// when the prototype exposes it.
+		const originalGetDisplayText = proto.getDisplayText;
+		if (typeof originalGetDisplayText === "function") {
+			proto.__f2gOriginalGetDisplayText = originalGetDisplayText;
+			proto.getDisplayText = function () {
+				if (this.type === HEADING_NODE_TAG) {
+					return patcher.extractHeadingFromNodeId(this.id);
+				}
+				return originalGetDisplayText.call(this);
+			};
+		}
+
+		// Patch the node render method (its name varies across Obsidian builds)
+		// so that, once per node instance, the PIXI listeners of the node circle
+		// are wrapped to intercept Shift+right-click. Obsidian registers its own
+		// circle listeners BEFORE ours, so simply adding another listener could
+		// not prevent the native behaviour — the existing listeners are detached
+		// and re-invoked conditionally instead.
+		const renderMethodName = (["render", "draw", "updateGraphics"] as const).find(
+			(name) => typeof proto[name] === "function",
+		) as string | undefined;
+
+		if (renderMethodName) {
+			const originalRender = proto[renderMethodName];
+			proto[`__f2gOriginal_${renderMethodName}`] = originalRender;
+
+			proto[renderMethodName] = function (...args: unknown[]) {
+				originalRender.apply(this, args);
+
+				// Early-out: nothing to do if there is no PIXI circle to patch.
+				if (!this.circle) return;
+
+				// Wrap the circle's PIXI listeners once per node instance. The
+				// wrapping is discarded naturally when unload/load reconstructs
+				// the graph view nodes.
+				if (!this.__f2gRightClickWrapped) {
+					this.__f2gRightClickWrapped = true;
+					try {
+						const circle = this.circle as {
+							on?: (event: string, fn: (e: unknown) => void, ctx?: unknown) => void;
+							off?: (event: string, fn: (e: unknown) => void) => void;
+							listeners?: (event: string) => Array<(e: unknown) => void>;
+						};
+						const nodeId: string = this.id;
+
+						// Helper: detach all existing listeners for an event and return them.
+						const detach = (eventName: string): Array<(e: unknown) => void> => {
+							const fns = circle.listeners?.(eventName) ?? [];
+							for (const fn of fns) {
+								circle.off?.(eventName, fn);
+							}
+							return fns;
+						};
+
+						// Helper: forward an event to all original listeners.
+						const forward = (fns: Array<(e: unknown) => void>, e: unknown) => {
+							for (const fn of fns) {
+								fn.call(undefined, e);
+							}
+						};
+
+						// Wrap rightdown: the gate that triggers unfold and sets the suppress flag.
+						const origRightdown = detach("rightdown");
+						circle.on?.("rightdown", (e: unknown) => {
+							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
+							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
+							if (native?.shiftKey && patcher.hierarchy.hasHiddenDescendant(nodeId)) {
+								patcher.setSuppressNextContextMenu(true);
+								patcher.handleRecursiveUnfold(nodeId);
+								// Do NOT forward — we are suppressing the native context menu.
+								return;
+							}
+							forward(origRightdown, e);
+						});
+
+						// Wrap rightup: swallow if the suppress flag is already set (same gesture).
+						const origRightup = detach("rightup");
+						circle.on?.("rightup", (e: unknown) => {
+							if (patcher.getSuppressNextContextMenu()) {
+								// Flag still set → this rightup belongs to the swallowed gesture.
+								return;
+							}
+							forward(origRightup, e);
+						});
+
+						// Wrap rightclick: same — swallow companion events of the same gesture.
+						const origRightclick = detach("rightclick");
+						circle.on?.("rightclick", (e: unknown) => {
+							if (patcher.getSuppressNextContextMenu()) {
+								return;
+							}
+							forward(origRightclick, e);
+						});
+
+						// Wrap pointerdown: swallow only button=2 + Shift + hiddenDescendant to
+						// avoid interfering with left-button drag/navigation events.
+						const origPointerdown = detach("pointerdown");
+						circle.on?.("pointerdown", (e: unknown) => {
+							const ev = e as { data?: { originalEvent?: MouseEvent }; nativeEvent?: MouseEvent };
+							const native = ev?.data?.originalEvent ?? ev?.nativeEvent;
+							if (
+								native?.button === 2 &&
+								native?.shiftKey &&
+								patcher.hierarchy.hasHiddenDescendant(nodeId)
+							) {
+								// Swallow — rightdown handles the actual action.
+								return;
+							}
+							forward(origPointerdown, e);
+						});
+					} catch (err) {
+						// Silently ignore — if the PIXI API differs, native behaviour is preserved.
+					}
+				}
+
+				const isCollapsed = patcher.hierarchy.isCollapsed(this.id);
+
+				if (isCollapsed) {
+					// ── FOLDED STATE ──────────────────────────────────────────────────────
+					// Redraw the half-disc every frame so that:
+					//   • the orientation tracks the parent as positions change during layout,
+					//   • any full-circle repaint by Obsidian (e.g. on hover) is overridden.
+					// This is bounded to the number of visible collapsed nodes, so it is
+					// acceptable in practice.
+					try {
+						// Measure the native base radius AND centre from the local geometry on
+						// first encounter (before we clear it). Both are cached per-instance.
+						// Obsidian draws the circle at a large local radius (~100) and uses the
+						// DisplayObject scale for sizing, so getSize() is wrong here.
+						// The centre must be captured because PIXI geometry is not necessarily
+						// centred on (0, 0) — drawing at (0, 0) would appear shifted by one
+						// radius. Fallbacks: radius=100, centre=(0, 0).
+						//
+						// Color: draw in white (0xffffff) so that Obsidian's per-frame `tint`
+						// on the DisplayObject applies the correct node colour (hover included),
+						// exactly as the native full circle does.
+						if (!this.__f2gBaseRadius) {
+							let r = 0;
+							let cx = 0;
+							let cy = 0;
+							if (typeof this.circle.getLocalBounds === "function") {
+								const b = this.circle.getLocalBounds();
+								r = Math.max(b.width, b.height) / 2;
+								cx = b.x + b.width / 2;
+								cy = b.y + b.height / 2;
+							}
+							this.__f2gBaseRadius = r > 0 && isFinite(r) ? r : 100;
+							this.__f2gBaseCenter = { x: cx, y: cy };
+						}
+						const baseRadius: number = this.__f2gBaseRadius;
+						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
+						const cx: number = baseCenter.x;
+						const cy: number = baseCenter.y;
+
+						// Determine the angle pointing toward the structural parent: the rounded
+						// side of the half-disc faces the parent (arc from angle − π/2 to
+						// angle + π/2). Renderer coordinates and PIXI arc angles share the same
+						// y-down convention, so atan2 gives the correct on-screen direction.
+						// Falls back to upward (−π/2) when the parent position is unavailable.
+						let angle = -Math.PI / 2;
+						const parentId = patcher.hierarchy.getParent(this.id);
+						if (parentId !== undefined) {
+							// O(1) lookup through this.renderer.nodeLookup when available,
+							// falling back to a scan of this.renderer.nodes. Always read from
+							// the per-instance renderer — the prototype is shared across all
+							// graph leaves, so no renderer reference may be captured here.
+							const r = this.renderer;
+							let parentNode: { x: number; y: number } | undefined;
+							if (r?.nodeLookup) {
+								parentNode = r.nodeLookup[parentId];
+							} else if (r?.nodes) {
+								parentNode = r.nodes.find((n: { id: string }) => n.id === parentId);
+							}
+							if (parentNode) {
+								angle = Math.atan2(parentNode.y - this.y, parentNode.x - this.x);
+							}
+						}
+
+						this.circle.clear();
+						this.circle.beginFill(0xffffff, 1);
+						this.circle.moveTo(cx, cy);
+						this.circle.arc(cx, cy, baseRadius, angle - Math.PI / 2, angle + Math.PI / 2);
+						if (typeof this.circle.closePath === "function") {
+							this.circle.closePath();
+						}
+						this.circle.endFill();
+
+						this.__f2gHalfDrawn = true;
+					} catch (err) {
+						// Restore the normal circle if the custom drawing failed mid-way — a
+						// clear() without a successful redraw would leave the node invisible.
+						try {
+							originalRender.apply(this, args);
+						} catch (err2) {
+							// Silently ignore if originalRender also fails.
+						}
+					}
+				} else if (this.__f2gHalfDrawn) {
+					// ── TRANSITION: just unfolded ── restore the full circle once. Obsidian
+					// does not redraw the circle geometry on its own, so a custom drawing
+					// persists until we replace it ourselves.
+					try {
+						const baseRadius: number = this.__f2gBaseRadius ?? 100;
+						const baseCenter: { x: number; y: number } = this.__f2gBaseCenter ?? { x: 0, y: 0 };
+
+						this.circle.clear();
+						this.circle.beginFill(0xffffff, 1);
+						if (typeof this.circle.drawCircle === "function") {
+							this.circle.drawCircle(baseCenter.x, baseCenter.y, baseRadius);
+						} else {
+							this.circle.moveTo(baseCenter.x, baseCenter.y);
+							this.circle.arc(baseCenter.x, baseCenter.y, baseRadius, 0, 2 * Math.PI);
+						}
+						this.circle.endFill();
+					} catch (err) {
+						try {
+							originalRender.apply(this, args);
+						} catch (err2) {
+							// Silently ignore if originalRender also fails.
+						}
+					}
+					this.__f2gHalfDrawn = false;
+				}
+			};
+		}
+
+		proto.__f2gPatched = true;
+	}
+
+	/**
+	 * Restores the original `getFillColor`, `getDisplayText`, and render method
+	 * on the Node prototype. Called on plugin unload.
+	 */
+	unpatch(renderer: LeafRenderer): void {
+		if (renderer.nodes.length === 0) return;
+
+		const proto = Object.getPrototypeOf(renderer.nodes[0]);
+		if (!proto.__f2gPatched) return;
+
+		proto.getFillColor = proto.__f2gOriginalGetFillColor;
+		delete proto.__f2gOriginalGetFillColor;
+
+		if (proto.__f2gOriginalGetDisplayText) {
+			proto.getDisplayText = proto.__f2gOriginalGetDisplayText;
+			delete proto.__f2gOriginalGetDisplayText;
+		}
+
+		// Restore the patched render method, whichever name was found at patch time.
+		for (const name of ["render", "draw", "updateGraphics"]) {
+			const savedName = `__f2gOriginal_${name}`;
+			if (proto[savedName]) {
+				proto[name] = proto[savedName];
+				delete proto[savedName];
+			}
+		}
+
+		delete proto.__f2gPatched;
+	}
+
+	/**
+	 * Converts a CSS hex colour string to the 24-bit integer format used by
+	 * Obsidian's graph renderer (and PIXI). The colour is stored as hex and the
+	 * renderer expects the concatenation of the 8-bit binary values of each
+	 * RGB channel.
+	 *
+	 * @example
+	 * const color = "#001100"; // (00000000 00010001 00000000)
+	 * const result = getColorNumber(color);
+	 * // result = 4352
+	 */
+	getColorNumber(hexColor: string): number {
+		const r = parseInt(hexColor.substring(1, 3), 16).toString(2).padStart(8, "0");
+		const g = parseInt(hexColor.substring(3, 5), 16).toString(2).padStart(8, "0");
+		const b = parseInt(hexColor.substring(5, 7), 16).toString(2).padStart(8, "0");
+
+		return parseInt(r + g + b, 2);
+	}
+
+	/**
+	 * Extracts the heading portion of a heading node ID (`path#heading` →
+	 * `heading`). Uses `indexOf` (first `#`) so that headings whose text
+	 * itself contains `#` are handled consistently — such IDs are a known
+	 * degraded case. Falls back to the full ID when no `#` is present.
+	 */
+	extractHeadingFromNodeId(nodeId: string): string {
+		const idx = nodeId.indexOf("#");
+		return idx >= 0 ? nodeId.slice(idx + 1) : nodeId;
+	}
+}

--- a/src/graph/StructuralHierarchy.ts
+++ b/src/graph/StructuralHierarchy.ts
@@ -1,0 +1,137 @@
+import { Settings } from "interfaces/Settings";
+
+/**
+ * Manages the structural parent/child maps for the graph hierarchy.
+ *
+ * This class is pure state — it has no Obsidian dependency. It tracks which
+ * nodes are structural parents/children (folders contain files; files contain
+ * headings) and provides collapsed-state queries used by the renderer.
+ */
+export class StructuralHierarchy {
+	/** For every node ID, the list of IDs that are its direct structural children
+	 * (sub-folders, direct files, or headings). */
+	private children: Record<string, string[]> = {};
+
+	/** Inverse of `children`: maps each child node ID to its structural parent. */
+	private parent: Record<string, string> = {};
+
+	/** Pre-computed set of node IDs that are currently fully collapsed. Updated
+	 * by `computeCollapsedSet` once per setData for O(1) frame-time lookups. */
+	private collapsedNodeIds: Set<string> = new Set();
+
+	/** Reference to plugin settings, used to read `hiddenNodes`. */
+	private settings: Settings;
+
+	constructor(settings: Settings) {
+		this.settings = settings;
+	}
+
+	/** Clears both maps in preparation for a fresh setData pass. */
+	reset(): void {
+		this.children = {};
+		this.parent = {};
+	}
+
+	/**
+	 * Registers `childId` as a structural child of `parentId` in both maps.
+	 *
+	 * Self-relationships are ignored: the root folder `/` is its own computed
+	 * parent (`getNodeParentFolder("/")` returns `/`), and registering it as its
+	 * own child would make folding the root hide the root node itself.
+	 */
+	addChild(parentId: string, childId: string): void {
+		if (parentId === childId) return;
+		if (!this.children[parentId]) {
+			this.children[parentId] = [];
+		}
+		this.children[parentId].push(childId);
+		this.parent[childId] = parentId;
+	}
+
+	/**
+	 * Returns all structural descendants of `nodeId` via an iterative
+	 * depth-first traversal of the children map. A `visited` Set guards
+	 * against accidental cycles.
+	 */
+	getAllDescendants(nodeId: string): string[] {
+		const descendants: string[] = [];
+		const visited = new Set<string>();
+		const stack: string[] = [...(this.children[nodeId] ?? [])];
+
+		while (stack.length > 0) {
+			const current = stack.pop()!;
+			if (visited.has(current)) continue;
+			visited.add(current);
+			descendants.push(current);
+			const kids = this.children[current];
+			if (kids) {
+				for (const child of kids) {
+					stack.push(child);
+				}
+			}
+		}
+
+		return descendants;
+	}
+
+	/**
+	 * Returns the direct structural children of `nodeId`, or an empty array if
+	 * none are registered.
+	 */
+	getChildren(nodeId: string): string[] {
+		return this.children[nodeId] ?? [];
+	}
+
+	/**
+	 * Returns the structural parent ID of `nodeId`, or `undefined` if `nodeId`
+	 * is a root-level node with no registered parent.
+	 */
+	getParent(nodeId: string): string | undefined {
+		return this.parent[nodeId];
+	}
+
+	/**
+	 * Returns true if `nodeId` is fully collapsed: it has at least one
+	 * structural child and every descendant is present in `settings.hiddenNodes`.
+	 * For frame-time use, prefer `isCollapsed(nodeId)` after `computeCollapsedSet`.
+	 */
+	private isNodeCollapsed(nodeId: string): boolean {
+		const kids = this.children[nodeId];
+		if (!kids || kids.length === 0) return false;
+		const descendants = this.getAllDescendants(nodeId);
+		if (descendants.length === 0) return false;
+		return descendants.every((id) => this.settings.hiddenNodes[id]);
+	}
+
+	/**
+	 * Builds the full set of collapsed node IDs from the current children map
+	 * and `settings.hiddenNodes`. Call this once per setData so frame-time
+	 * rendering can do O(1) `isCollapsed(id)` lookups.
+	 */
+	computeCollapsedSet(): void {
+		const collapsed = new Set<string>();
+		for (const nodeId of Object.keys(this.children)) {
+			if (this.isNodeCollapsed(nodeId)) {
+				collapsed.add(nodeId);
+			}
+		}
+		this.collapsedNodeIds = collapsed;
+	}
+
+	/**
+	 * Returns true if `nodeId` is in the pre-computed collapsed set.
+	 * Only accurate after `computeCollapsedSet` has been called for the
+	 * current graph data.
+	 */
+	isCollapsed(nodeId: string): boolean {
+		return this.collapsedNodeIds.has(nodeId);
+	}
+
+	/**
+	 * Returns true if at least one structural descendant of `nodeId` is
+	 * currently hidden in `settings.hiddenNodes`.
+	 */
+	hasHiddenDescendant(nodeId: string): boolean {
+		return this.getAllDescendants(nodeId).some((id) => this.settings.hiddenNodes[id]);
+	}
+}

--- a/src/graph/StructuralHierarchy.ts
+++ b/src/graph/StructuralHierarchy.ts
@@ -6,6 +6,16 @@ import { Settings } from "interfaces/Settings";
  * This class is pure state — it has no Obsidian dependency. It tracks which
  * nodes are structural parents/children (folders contain files; files contain
  * headings) and provides collapsed-state queries used by the renderer.
+ *
+ * @remarks
+ * "Structural" relationships are hierarchy links injected by this plugin:
+ * - folder → direct child folder
+ * - folder → file it contains
+ * - file → root heading
+ * - heading → direct sub-heading
+ *
+ * Regular note-to-note wikilinks are NOT structural and are never registered
+ * here.
  */
 export class StructuralHierarchy {
 	/** For every node ID, the list of IDs that are its direct structural children
@@ -22,11 +32,22 @@ export class StructuralHierarchy {
 	/** Reference to plugin settings, used to read `hiddenNodes`. */
 	private settings: Settings;
 
+	/**
+	 * @param settings Plugin settings object. The instance is shared with the
+	 *   plugin so mutations to `settings.hiddenNodes` are visible here without
+	 *   re-injection.
+	 */
 	constructor(settings: Settings) {
 		this.settings = settings;
 	}
 
-	/** Clears both maps in preparation for a fresh setData pass. */
+	/**
+	 * Clears both maps in preparation for a fresh setData pass.
+	 *
+	 * @remarks
+	 * Must be called at the start of every `GraphDataInjector.install` callback
+	 * so stale relationships from the previous graph state are not carried over.
+	 */
 	reset(): void {
 		this.children = {};
 		this.parent = {};
@@ -35,9 +56,14 @@ export class StructuralHierarchy {
 	/**
 	 * Registers `childId` as a structural child of `parentId` in both maps.
 	 *
-	 * Self-relationships are ignored: the root folder `/` is its own computed
-	 * parent (`getNodeParentFolder("/")` returns `/`), and registering it as its
-	 * own child would make folding the root hide the root node itself.
+	 * @param parentId ID of the structural parent node.
+	 * @param childId  ID of the structural child node.
+	 *
+	 * @remarks
+	 * Self-relationships are silently ignored: the root folder `/` is its own
+	 * computed parent (`getNodeParentFolder("/")` returns `/`), and registering
+	 * it as its own child would cause folding the root to hide the root node
+	 * itself.
 	 */
 	addChild(parentId: string, childId: string): void {
 		if (parentId === childId) return;
@@ -50,8 +76,16 @@ export class StructuralHierarchy {
 
 	/**
 	 * Returns all structural descendants of `nodeId` via an iterative
-	 * depth-first traversal of the children map. A `visited` Set guards
-	 * against accidental cycles.
+	 * depth-first traversal of the children map.
+	 *
+	 * @param nodeId The node whose subtree is to be collected.
+	 * @returns Flat array of all descendant node IDs in DFS order; empty when
+	 *   `nodeId` has no registered children.
+	 *
+	 * @remarks
+	 * A `visited` Set guards against accidental cycles in the children map,
+	 * which should never occur in normal use but could arise from corrupted
+	 * state.
 	 */
 	getAllDescendants(nodeId: string): string[] {
 		const descendants: string[] = [];
@@ -75,16 +109,21 @@ export class StructuralHierarchy {
 	}
 
 	/**
-	 * Returns the direct structural children of `nodeId`, or an empty array if
-	 * none are registered.
+	 * Returns the direct structural children of `nodeId`.
+	 *
+	 * @param nodeId The node to query.
+	 * @returns The children array, or an empty array if none are registered.
 	 */
 	getChildren(nodeId: string): string[] {
 		return this.children[nodeId] ?? [];
 	}
 
 	/**
-	 * Returns the structural parent ID of `nodeId`, or `undefined` if `nodeId`
-	 * is a root-level node with no registered parent.
+	 * Returns the structural parent ID of `nodeId`.
+	 *
+	 * @param nodeId The node to query.
+	 * @returns The parent node ID, or `undefined` if `nodeId` is a root-level
+	 *   node with no registered parent.
 	 */
 	getParent(nodeId: string): string | undefined {
 		return this.parent[nodeId];
@@ -92,8 +131,14 @@ export class StructuralHierarchy {
 
 	/**
 	 * Returns true if `nodeId` is fully collapsed: it has at least one
-	 * structural child and every descendant is present in `settings.hiddenNodes`.
-	 * For frame-time use, prefer `isCollapsed(nodeId)` after `computeCollapsedSet`.
+	 * structural child and every descendant is present in
+	 * `settings.hiddenNodes`.
+	 *
+	 * @param nodeId The node to test.
+	 *
+	 * @remarks
+	 * For frame-time use, prefer `isCollapsed(nodeId)` after
+	 * `computeCollapsedSet` has been called for the current graph data.
 	 */
 	private isNodeCollapsed(nodeId: string): boolean {
 		const kids = this.children[nodeId];
@@ -105,8 +150,12 @@ export class StructuralHierarchy {
 
 	/**
 	 * Builds the full set of collapsed node IDs from the current children map
-	 * and `settings.hiddenNodes`. Call this once per setData so frame-time
-	 * rendering can do O(1) `isCollapsed(id)` lookups.
+	 * and `settings.hiddenNodes`, replacing `collapsedNodeIds`.
+	 *
+	 * @remarks
+	 * Called once per `setData` pass by `GraphDataInjector` so that
+	 * `NodePrototypePatcher`'s render override can do O(1)
+	 * `isCollapsed(id)` lookups instead of recomputing per node per frame.
 	 */
 	computeCollapsedSet(): void {
 		const collapsed = new Set<string>();
@@ -120,8 +169,14 @@ export class StructuralHierarchy {
 
 	/**
 	 * Returns true if `nodeId` is in the pre-computed collapsed set.
+	 *
+	 * @param nodeId The node to test.
+	 * @returns `true` when every structural descendant of `nodeId` is hidden.
+	 *
+	 * @remarks
 	 * Only accurate after `computeCollapsedSet` has been called for the
-	 * current graph data.
+	 * current graph data. Used in the PIXI render override to decide whether
+	 * to draw the half-disc.
 	 */
 	isCollapsed(nodeId: string): boolean {
 		return this.collapsedNodeIds.has(nodeId);
@@ -130,6 +185,13 @@ export class StructuralHierarchy {
 	/**
 	 * Returns true if at least one structural descendant of `nodeId` is
 	 * currently hidden in `settings.hiddenNodes`.
+	 *
+	 * @param nodeId The node to test.
+	 *
+	 * @remarks
+	 * Used by both the PIXI right-click wrapper (to decide whether to swallow
+	 * the gesture) and `FoldingManager.handleRecursiveUnfold` (to decide
+	 * whether there is anything to reveal).
 	 */
 	hasHiddenDescendant(nodeId: string): boolean {
 		return this.getAllDescendants(nodeId).some((id) => this.settings.hiddenNodes[id]);

--- a/src/graph/StructuralHierarchy.ts
+++ b/src/graph/StructuralHierarchy.ts
@@ -64,6 +64,17 @@ export class StructuralHierarchy {
 	 * computed parent (`getNodeParentFolder("/")` returns `/`), and registering
 	 * it as its own child would cause folding the root to hide the root node
 	 * itself.
+	 *
+	 * @example
+	 * // Register a folder → file relationship.
+	 * hierarchy.addChild("/projects", "projects/tasks.md");
+	 * // hierarchy.getChildren("/projects") = ["projects/tasks.md"]
+	 * // hierarchy.getParent("projects/tasks.md") = "/projects"
+	 *
+	 * @example
+	 * // Self-reference (vault root) is silently ignored.
+	 * hierarchy.addChild("/", "/");
+	 * // hierarchy.getChildren("/") = []  (unchanged)
 	 */
 	addChild(parentId: string, childId: string): void {
 		if (parentId === childId) return;
@@ -86,6 +97,20 @@ export class StructuralHierarchy {
 	 * A `visited` Set guards against accidental cycles in the children map,
 	 * which should never occur in normal use but could arise from corrupted
 	 * state.
+	 *
+	 * @example
+	 * // Given the tree:  /work  →  work/project  →  work/project/note.md
+	 * //                                           →  work/project/readme.md
+	 * hierarchy.addChild("/work", "work/project");
+	 * hierarchy.addChild("work/project", "work/project/note.md");
+	 * hierarchy.addChild("work/project", "work/project/readme.md");
+	 *
+	 * const result = hierarchy.getAllDescendants("/work");
+	 * // result contains ["work/project", "work/project/readme.md", "work/project/note.md"]
+	 * // (DFS order; exact ordering depends on stack pop sequence)
+	 *
+	 * const empty = hierarchy.getAllDescendants("work/project/note.md");
+	 * // empty = []
 	 */
 	getAllDescendants(nodeId: string): string[] {
 		const descendants: string[] = [];
@@ -156,6 +181,21 @@ export class StructuralHierarchy {
 	 * Called once per `setData` pass by `GraphDataInjector` so that
 	 * `NodePrototypePatcher`'s render override can do O(1)
 	 * `isCollapsed(id)` lookups instead of recomputing per node per frame.
+	 *
+	 * @example
+	 * // Hierarchy: /src → src/index.md, src/utils.md
+	 * // hiddenNodes = { "src/index.md": true, "src/utils.md": true }
+	 * // (all descendants of "/src" are hidden)
+	 *
+	 * hierarchy.computeCollapsedSet();
+	 * hierarchy.isCollapsed("/src");
+	 * // true  — both children are hidden
+	 *
+	 * // If only one child is hidden:
+	 * // hiddenNodes = { "src/index.md": true }
+	 * hierarchy.computeCollapsedSet();
+	 * hierarchy.isCollapsed("/src");
+	 * // false — src/utils.md is still visible
 	 */
 	computeCollapsedSet(): void {
 		const collapsed = new Set<string>();
@@ -177,6 +217,14 @@ export class StructuralHierarchy {
 	 * Only accurate after `computeCollapsedSet` has been called for the
 	 * current graph data. Used in the PIXI render override to decide whether
 	 * to draw the half-disc.
+	 *
+	 * @example
+	 * // After computeCollapsedSet() with hiddenNodes covering all of /src's descendants:
+	 * hierarchy.isCollapsed("/src");
+	 * // true  — renders as a half-disc
+	 *
+	 * hierarchy.isCollapsed("src/index.md");
+	 * // false — leaf node (no children), never considered collapsed
 	 */
 	isCollapsed(nodeId: string): boolean {
 		return this.collapsedNodeIds.has(nodeId);
@@ -192,6 +240,19 @@ export class StructuralHierarchy {
 	 * Used by both the PIXI right-click wrapper (to decide whether to swallow
 	 * the gesture) and `FoldingManager.handleRecursiveUnfold` (to decide
 	 * whether there is anything to reveal).
+	 *
+	 * @example
+	 * // Hierarchy: /docs → docs/guide.md → docs/guide.md#Introduction
+	 * // hiddenNodes = { "docs/guide.md#Introduction": true }
+	 *
+	 * hierarchy.hasHiddenDescendant("/docs");
+	 * // true  — a grandchild is hidden
+	 *
+	 * hierarchy.hasHiddenDescendant("docs/guide.md");
+	 * // true  — a direct child (the heading node) is hidden
+	 *
+	 * hierarchy.hasHiddenDescendant("docs/guide.md#Introduction");
+	 * // false — leaf node, no descendants at all
 	 */
 	hasHiddenDescendant(nodeId: string): boolean {
 		return this.getAllDescendants(nodeId).some((id) => this.settings.hiddenNodes[id]);

--- a/src/i18n/enUS.ts
+++ b/src/i18n/enUS.ts
@@ -1,5 +1,12 @@
 import { I18n } from "types/I18n";
 
+/**
+ * English (United States) locale strings.
+ *
+ * @remarks
+ * Used as the default locale when no matching language code is found in
+ * `localStorage`.
+ */
 export const enUS: I18n = {
 	settings: {
 		showFolderNodes: {

--- a/src/i18n/enUS.ts
+++ b/src/i18n/enUS.ts
@@ -30,5 +30,8 @@ export const enUS: I18n = {
 		toggleHeadingNodes: {
 			name: "Show or hide heading nodes",
 		},
+		unfoldAllNodes: {
+			name: "Unfold all graph nodes",
+		},
 	},
 };

--- a/src/i18n/frFR.ts
+++ b/src/i18n/frFR.ts
@@ -1,5 +1,11 @@
 import { I18n } from "types/I18n";
 
+/**
+ * French (France) locale strings.
+ *
+ * @remarks
+ * Selected when `localStorage.getItem("language")` returns `"fr"`.
+ */
 export const frFR: I18n = {
 	settings: {
 		showFolderNodes: {

--- a/src/i18n/frFR.ts
+++ b/src/i18n/frFR.ts
@@ -30,5 +30,8 @@ export const frFR: I18n = {
 		toggleHeadingNodes: {
 			name: "Afficher ou masquer les nœuds de titre",
 		},
+		unfoldAllNodes: {
+			name: "Déplier tous les nœuds du graphe",
+		},
 	},
 };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,8 +5,15 @@ import { frFR } from "./frFR";
 export { enUS, frFR };
 
 /**
- * Returns the I18n object matching the language code stored in Obsidian's localStorage.
- * Defaults to English when no match is found.
+ * Returns the {@link I18n} object matching the language code stored in
+ * Obsidian's `localStorage`. Defaults to English when no match is found.
+ *
+ * @returns The active locale object.
+ *
+ * @remarks
+ * Obsidian writes the user's chosen language to `localStorage` under the key
+ * `"language"` (e.g. `"en"`, `"fr"`). This function is called at plugin load
+ * time and whenever UI strings need to be rendered.
  */
 export function getI18n(): I18n {
 	switch (window.localStorage.getItem("language")) {

--- a/src/interfaces/GraphLeafWithCustomRenderer.ts
+++ b/src/interfaces/GraphLeafWithCustomRenderer.ts
@@ -7,6 +7,9 @@ type CustomLeaf = {
 		getViewType: () => string;
 		unload: () => void;
 		load: () => void;
+		/** DOM container of the graph view. Present on all Obsidian views; used to install
+		 * the contextmenu suppression listener. */
+		containerEl: HTMLElement;
 	};
 };
 

--- a/src/interfaces/GraphLeafWithCustomRenderer.ts
+++ b/src/interfaces/GraphLeafWithCustomRenderer.ts
@@ -1,16 +1,39 @@
 import { WorkspaceLeaf } from "obsidian";
 import { LeafRenderer } from "./LeafRenderer";
 
+/**
+ * Augmented `WorkspaceLeaf` type that exposes the graph view's internal
+ * renderer and the DOM container element.
+ *
+ * @remarks
+ * Obsidian's `WorkspaceLeaf` does not publicly type the `view` property beyond
+ * a generic `View`. This intersection type narrows the shape to what the plugin
+ * actually uses, reducing the need for `as unknown` casts.
+ *
+ * The `renderer` may be `undefined` immediately after the leaf is created and
+ * before the graph view finishes initialising — all consumers must guard
+ * against this (see `Folders2GraphPlugin.__isReadyGraphLeaf`).
+ */
 type CustomLeaf = {
 	view: {
+		/** The internal graph renderer. May be `undefined` during view
+		 * initialisation; guard with `__isReadyGraphLeaf` before use. */
 		renderer: LeafRenderer;
+		/** Returns the Obsidian view type identifier (e.g. `"graph"`). */
 		getViewType: () => string;
+		/** Tears down the view's internal state and listeners. */
 		unload: () => void;
+		/** Re-initialises the view. Called after `unload` to apply changes
+		 * made by the plugin's `setData` override. */
 		load: () => void;
-		/** DOM container of the graph view. Present on all Obsidian views; used to install
-		 * the contextmenu suppression listener. */
+		/** DOM container of the graph view. Used to install the contextmenu
+		 * suppression listener in `GraphInteractions`. */
 		containerEl: HTMLElement;
 	};
 };
 
+/**
+ * A `WorkspaceLeaf` intersected with the graph-specific view shape used by
+ * this plugin.
+ */
 export type GraphLeafWithCustomRenderer = WorkspaceLeaf & CustomLeaf;

--- a/src/interfaces/GraphLeafWithCustomRenderer.ts
+++ b/src/interfaces/GraphLeafWithCustomRenderer.ts
@@ -4,6 +4,9 @@ import { LeafRenderer } from "./LeafRenderer";
 type CustomLeaf = {
 	view: {
 		renderer: LeafRenderer;
+		getViewType: () => string;
+		unload: () => void;
+		load: () => void;
 	};
 };
 

--- a/src/interfaces/GraphNode.ts
+++ b/src/interfaces/GraphNode.ts
@@ -1,5 +1,21 @@
+/**
+ * Represents a single node in the graph data passed to Obsidian's renderer via
+ * `setData`.
+ *
+ * @remarks
+ * The `type` field is used by the plugin to distinguish injected folder nodes
+ * (`f2g_node`) and heading nodes (`f2g_heading_node`) from native file nodes.
+ * The `folderNode` flag provides a secondary marker used when iterating the
+ * node map to build structural links (a folder node whose `folderNode` is
+ * `true` is treated as a regular child for link-wiring purposes).
+ */
 export type GraphNode = {
+	/** Node type tag. Native file nodes have an empty string or Obsidian-internal
+	 * value; injected folder nodes use `"f2g_node"`; heading nodes use
+	 * `"f2g_heading_node"`. */
 	type: string;
+	/** Map from target node ID to `true`, representing outgoing graph links. */
 	links: Record<string, boolean>;
+	/** Present and `true` on injected folder nodes. */
 	folderNode?: boolean;
 };

--- a/src/interfaces/LeafRenderer.ts
+++ b/src/interfaces/LeafRenderer.ts
@@ -2,9 +2,43 @@ export type LeafRenderer = {
 	setData: Function;
 	originalSetData?: Function;
 	nodes: Array<{
+		id: string;
+		x: number;
+		y: number;
+		type: string;
+		getSize?: () => number;
 		getFillColor: () => { a: number; rgb: number };
 		originalGetFillColor?: () => { a: number; rgb: number };
-		type: string;
+		/** PIXI Graphics object used to draw the node circle. May be absent on some
+		 * renderer builds; access must always be guarded. */
+		circle?: {
+			clear: () => void;
+			beginFill: (color: number, alpha?: number) => void;
+			moveTo: (x: number, y: number) => void;
+			arc: (cx: number, cy: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean) => void;
+			/** PIXI Graphics full-circle helper. Used when restoring a collapsed node to a
+			 * full circle. Falls back to a full arc (0 → 2π) when absent. */
+			drawCircle?: (x: number, y: number, radius: number) => void;
+			closePath?: () => void;
+			endFill: () => void;
+			/** Returns the local axis-aligned bounding box of the drawn geometry. Used to
+			 * measure the native base radius and centre before any scale is applied.
+			 * `x` and `y` are the top-left corner of the bounding box in local space. */
+			getLocalBounds?: () => { x: number; y: number; width: number; height: number };
+			/** PIXI tint colour applied by Obsidian's renderer each frame. Present on PIXI
+			 * DisplayObject; stored here for type-narrowing convenience only. */
+			tint?: number;
+			/** PIXI EventEmitter — registers a listener for the given event name. */
+			on?: (event: string, fn: (e: unknown) => void, ctx?: unknown) => void;
+			/** PIXI EventEmitter — removes a specific listener for the given event name. */
+			off?: (event: string, fn: (e: unknown) => void) => void;
+			/** PIXI EventEmitter (eventemitter3) — returns the array of listeners currently
+			 * registered for the given event name. */
+			listeners?: (event: string) => Array<(e: unknown) => void>;
+		};
 	}>;
+	/** O(1) node lookup by ID, available in recent Obsidian builds. Falls back to scanning
+	 * `nodes` when absent. */
+	nodeLookup?: Record<string, { id: string; x: number; y: number }>;
 	changed: () => void;
 };

--- a/src/interfaces/LeafRenderer.ts
+++ b/src/interfaces/LeafRenderer.ts
@@ -1,44 +1,83 @@
+/**
+ * Shape of Obsidian's internal graph renderer, as accessed through
+ * `leaf.view.renderer`.
+ *
+ * @remarks
+ * This is not part of Obsidian's public API. The fields and methods listed here
+ * have been determined by inspection of the Obsidian source and may change
+ * across Obsidian releases. All accesses in the plugin are guarded accordingly.
+ */
 export type LeafRenderer = {
+	/** Obsidian's native graph data setter. Replaced by the plugin with a
+	 * custom wrapper and restored on unload. */
 	setData: Function;
+	/** The original `setData` saved by the plugin before wrapping. Present only
+	 * while the plugin is active. */
 	originalSetData?: Function;
+	/** Array of graph node instances currently managed by this renderer. */
 	nodes: Array<{
+		/** Unique node identifier (file path, folder path, or heading wikilink). */
 		id: string;
+		/** Current x position in renderer-space coordinates. */
 		x: number;
+		/** Current y position in renderer-space coordinates (y-down). */
 		y: number;
+		/** Node type tag (see `GraphNode.type`). */
 		type: string;
+		/** Returns the display size of the node. Not used by the plugin because
+		 * Obsidian draws the circle at a fixed local radius (~100) and relies on
+		 * the DisplayObject scale — `getSize()` returns the wrong value for
+		 * geometry measurements. */
 		getSize?: () => number;
+		/** Returns the fill colour for this node. Patched by `NodePrototypePatcher`
+		 * to return the configured colour for folder and heading nodes. */
 		getFillColor: () => { a: number; rgb: number };
+		/** Original `getFillColor` saved by the prototype patch. */
 		originalGetFillColor?: () => { a: number; rgb: number };
-		/** PIXI Graphics object used to draw the node circle. May be absent on some
-		 * renderer builds; access must always be guarded. */
+		/** PIXI Graphics object used to draw the node circle. May be absent on
+		 * some renderer builds; all accesses must be guarded. */
 		circle?: {
+			/** Clears all drawn geometry. */
 			clear: () => void;
+			/** Begins a fill operation with the given colour and alpha.
+			 * @remarks Draw in white (`0xffffff`) so Obsidian's per-frame `tint`
+			 * on the DisplayObject applies the correct node colour, exactly as the
+			 * native full circle does. */
 			beginFill: (color: number, alpha?: number) => void;
+			/** Moves the drawing cursor to `(x, y)` without drawing. */
 			moveTo: (x: number, y: number) => void;
+			/** Draws an arc. Angles are in radians following PIXI's y-down convention,
+			 * so the same direction as screen coordinates — `atan2` gives the correct
+			 * on-screen angle without axis inversion. */
 			arc: (cx: number, cy: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean) => void;
-			/** PIXI Graphics full-circle helper. Used when restoring a collapsed node to a
-			 * full circle. Falls back to a full arc (0 → 2π) when absent. */
+			/** PIXI Graphics full-circle helper. Used when restoring a collapsed node
+			 * to a full circle. Falls back to a full arc (0 → 2π) when absent. */
 			drawCircle?: (x: number, y: number, radius: number) => void;
+			/** Closes the current path (connects the last point back to `moveTo`). */
 			closePath?: () => void;
+			/** Ends the fill operation and rasterises the geometry. */
 			endFill: () => void;
-			/** Returns the local axis-aligned bounding box of the drawn geometry. Used to
-			 * measure the native base radius and centre before any scale is applied.
-			 * `x` and `y` are the top-left corner of the bounding box in local space. */
+			/** Returns the local axis-aligned bounding box of the drawn geometry.
+			 * Used to measure the native base radius and centre before the first
+			 * custom draw. `x` and `y` are the top-left corner in local space. */
 			getLocalBounds?: () => { x: number; y: number; width: number; height: number };
-			/** PIXI tint colour applied by Obsidian's renderer each frame. Present on PIXI
-			 * DisplayObject; stored here for type-narrowing convenience only. */
+			/** PIXI tint colour applied by Obsidian's renderer each frame. Present on
+			 * PIXI DisplayObject; stored here for type-narrowing convenience only. */
 			tint?: number;
 			/** PIXI EventEmitter — registers a listener for the given event name. */
 			on?: (event: string, fn: (e: unknown) => void, ctx?: unknown) => void;
 			/** PIXI EventEmitter — removes a specific listener for the given event name. */
 			off?: (event: string, fn: (e: unknown) => void) => void;
-			/** PIXI EventEmitter (eventemitter3) — returns the array of listeners currently
-			 * registered for the given event name. */
+			/** PIXI EventEmitter (eventemitter3) — returns the array of listeners
+			 * currently registered for the given event name. Used by the prototype
+			 * patch to detach existing listeners before re-wiring them. */
 			listeners?: (event: string) => Array<(e: unknown) => void>;
 		};
 	}>;
-	/** O(1) node lookup by ID, available in recent Obsidian builds. Falls back to scanning
-	 * `nodes` when absent. */
+	/** O(1) node lookup by ID, available in recent Obsidian builds. Falls back
+	 * to a linear scan of `nodes` when absent. */
 	nodeLookup?: Record<string, { id: string; x: number; y: number }>;
+	/** Signals Obsidian's renderer that the data has changed and a re-render is
+	 * needed. */
 	changed: () => void;
 };

--- a/src/interfaces/RendererData.ts
+++ b/src/interfaces/RendererData.ts
@@ -1,6 +1,18 @@
 import { GraphNode } from "./GraphNode";
 
+/**
+ * The data object passed to Obsidian's internal graph renderer via `setData`.
+ *
+ * @remarks
+ * This is the shape of the argument that Obsidian passes to the internal
+ * `renderer.setData` method. The plugin intercepts this call to inject virtual
+ * folder and heading nodes before forwarding to the original implementation.
+ */
 export type RendererData = {
+	/** Total number of links across all nodes. */
 	numLinks: number;
+	/** Map from node ID to node data. The plugin mutates this map in-place to
+	 * add virtual nodes and to remove hidden ones before forwarding to the
+	 * original `setData`. */
 	nodes: Record<string, GraphNode>;
 };

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -17,7 +17,20 @@ export type Settings = {
 	showHeadingNodes: boolean;
 	/** CSS hex colour string for heading nodes (e.g. `"#f5a55c"`). */
 	headingNodeColor: string;
-	/** Node IDs that are hidden because a structural ancestor was collapsed by the user.
-	 * Persists across restarts so the collapsed state survives a vault reload. */
+	/**
+	 * Node IDs that are hidden because a structural ancestor was collapsed by the user.
+	 * Persists across restarts so the collapsed state survives a vault reload.
+	 *
+	 * @example
+	 * // After the user Shift+clicks the "/projects" folder node to collapse it,
+	 * // and the "/projects/archive" sub-folder was already collapsed independently:
+	 * hiddenNodes = {
+	 *   "projects/roadmap.md": true,
+	 *   "projects/archive": true,
+	 *   "projects/archive/old-spec.md": true,
+	 * }
+	 * // Folder IDs are `/`-prefixed; file IDs are plain paths or basenames;
+	 * // heading IDs use the `path#heading` wikilink format.
+	 */
 	hiddenNodes: Record<string, boolean>;
 };

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -1,8 +1,21 @@
+/**
+ * Persistent plugin settings stored in Obsidian's data store.
+ *
+ * @remarks
+ * All settings are read by `Folders2GraphPlugin.settings` and written through
+ * `Folders2GraphPlugin.saveSettings`. The `SettingsTab` reads and mutates this
+ * object directly via `plugin.settings`.
+ */
 export type Settings = {
+	/** Whether to inject virtual folder nodes into the graph. Defaults to `true`. */
 	showFolderNodes: boolean;
+	/** Whether to hide the vault-root folder node (`"/"`). Defaults to `false`. */
 	hideRootNode: boolean;
+	/** CSS hex colour string for folder nodes (e.g. `"#5c8af5"`). */
 	nodeColor: string;
+	/** Whether to inject heading nodes derived from Markdown files. Defaults to `false`. */
 	showHeadingNodes: boolean;
+	/** CSS hex colour string for heading nodes (e.g. `"#f5a55c"`). */
 	headingNodeColor: string;
 	/** Node IDs that are hidden because a structural ancestor was collapsed by the user.
 	 * Persists across restarts so the collapsed state survives a vault reload. */

--- a/src/interfaces/Settings.ts
+++ b/src/interfaces/Settings.ts
@@ -4,4 +4,7 @@ export type Settings = {
 	nodeColor: string;
 	showHeadingNodes: boolean;
 	headingNodeColor: string;
+	/** Node IDs that are hidden because a structural ancestor was collapsed by the user.
+	 * Persists across restarts so the collapsed state survives a vault reload. */
+	hiddenNodes: Record<string, boolean>;
 };

--- a/src/types/I18n.ts
+++ b/src/types/I18n.ts
@@ -28,5 +28,8 @@ export type I18n = {
 		toggleHeadingNodes: {
 			name: string;
 		};
+		unfoldAllNodes: {
+			name: string;
+		};
 	};
 };

--- a/src/types/I18n.ts
+++ b/src/types/I18n.ts
@@ -1,4 +1,12 @@
+/**
+ * Structure of the internationalisation object used throughout the plugin.
+ *
+ * @remarks
+ * Each locale module (`enUS`, `frFR`) exports a value that satisfies this type.
+ * The active locale is resolved at runtime by `getI18n` from `i18n/index.ts`.
+ */
 export type I18n = {
+	/** Strings used in the settings tab. */
 	settings: {
 		showFolderNodes: {
 			name: string;
@@ -21,6 +29,7 @@ export type I18n = {
 			desc: string;
 		};
 	};
+	/** Strings used for registered Obsidian commands. */
 	commands: {
 		toggleFolderNodes: {
 			name: string;

--- a/src/types/Nullable.ts
+++ b/src/types/Nullable.ts
@@ -1,1 +1,6 @@
+/**
+ * A value that may be `null`.
+ *
+ * @typeParam T The non-null type.
+ */
 export type Nullable<T> = T | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
 			"SettingsTab": ["./src/SettingsTab.ts"],
 			"i18n": ["./src/i18n/index.ts"],
 			"interfaces/*": ["./src/interfaces/*"],
-			"types/*": ["./src/types/*"]
+			"types/*": ["./src/types/*"],
+			"graph/*": ["./src/graph/*"]
 		},
 
 		"skipLibCheck": true,


### PR DESCRIPTION
Adds interactive folding of graph nodes (files, folders, headings):

- Shift+left-click on a node: hides all its structural descendants (fold). On a fully folded node, reveals direct children only (one level). On a mixed state, hides the remaining visible ones.
- Shift+right-click: recursively unfolds the whole subtree.
- Folded nodes are drawn as a half-disc oriented toward their parent (PIXI render patch, native tint preserved).
- Fold state is persisted in plugin data, survives restarts; stale entries are purged against the vault (toggle-independent). New nodes are visible by default; content under a folded-then-hidden parent stays hidden.
- New command: Unfold all graph nodes (no default hotkey).
- "Children" = structural hierarchy only (folder → subfolders/files, file → headings, heading → sub-headings); referenced notes are unaffected.

Also refactors Main.ts into five focused modules under src/graph/ (StructuralHierarchy, FoldingManager, GraphDataInjector, NodePrototypePatcher, GraphInteractions) with full TSDoc and examples. Global graph view only.